### PR TITLE
ECC-72 - dont have EORI link

### DIFF
--- a/app/uk/gov/hmrc/customs/rosmfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/config/AppConfig.scala
@@ -49,7 +49,7 @@ class AppConfig @Inject()(
   lazy val feedbackLink = config.get[String]("external-url.feedback-survey")
   lazy val feedbackLinkSubscribe = config.get[String]("external-url.feedback-survey-subscribe")
 
-  lazy val getEORILink = config.get[String]("external-url.get-cds-eori")
+  lazy val externalGetEORILink = config.get[String]("external-url.get-cds-eori")
 
   lazy val blockedRoutesRegex: Seq[Regex] = config.get[String]("routes-to-block").split(',').map(_.r).toSeq
 

--- a/app/uk/gov/hmrc/customs/rosmfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/config/AppConfig.scala
@@ -33,6 +33,8 @@ class AppConfig @Inject()(
 
   lazy val env: String = runMode.env
 
+  lazy val messageFiles: Seq[String] =  config.get[Seq[String]]("messages.file.names")
+
   lazy val ttl: Duration = Duration.create(config.get[String]("cds-frontend-cache.ttl"))
   lazy val allowlistReferrers: Seq[String] =
     config.get[String]("allowlist-referrers").split(',').map(_.trim).filter(_.nonEmpty)
@@ -46,6 +48,8 @@ class AppConfig @Inject()(
 
   lazy val feedbackLink = config.get[String]("external-url.feedback-survey")
   lazy val feedbackLinkSubscribe = config.get[String]("external-url.feedback-survey-subscribe")
+
+  lazy val getEORILink = config.get[String]("external-url.get-cds-eori")
 
   lazy val blockedRoutesRegex: Seq[Regex] = config.get[String]("routes-to-block").split(',').map(_.r).toSeq
 

--- a/app/uk/gov/hmrc/customs/rosmfrontend/controllers/RegisterRedirectController.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/controllers/RegisterRedirectController.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.rosmfrontend.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.Application
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.customs.rosmfrontend.config.AppConfig
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class RegisterRedirectController @Inject()(
+                                            override val currentApp: Application,
+                                            override val authConnector: AuthConnector,
+                                            mcc: MessagesControllerComponents,
+                                            appConfig: AppConfig
+                                          )(implicit ec: ExecutionContext)
+  extends CdsController(mcc) {
+
+  def getEori(): Action[AnyContent] = Action { implicit request =>
+    Redirect(appConfig.getEORILink)
+  }
+}

--- a/app/uk/gov/hmrc/customs/rosmfrontend/controllers/RegisterRedirectController.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/controllers/RegisterRedirectController.scala
@@ -34,6 +34,6 @@ class RegisterRedirectController @Inject()(
   extends CdsController(mcc) {
 
   def getEori(): Action[AnyContent] = Action { implicit request =>
-    Redirect(appConfig.getEORILink)
+    Redirect(appConfig.externalGetEORILink)
   }
 }

--- a/app/uk/gov/hmrc/customs/rosmfrontend/modules/EccMessagesApiProvider.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/modules/EccMessagesApiProvider.scala
@@ -24,7 +24,7 @@ import play.api.{Configuration, Environment}
 import scala.collection.breakOut
 
 @Singleton
-class MovementsMessagesApiProvider @Inject()(environment: Environment, config: Configuration, langs: Langs, httpConfiguration: HttpConfiguration)
+class EccMessagesApiProvider @Inject()(environment: Environment, config: Configuration, langs: Langs, httpConfiguration: HttpConfiguration)
     extends DefaultMessagesApiProvider(environment, config, langs, httpConfiguration) {
 
   override protected def loadAllMessages: Map[String, Map[String, String]] =

--- a/app/uk/gov/hmrc/customs/rosmfrontend/modules/MessagesApiProviderModule.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/modules/MessagesApiProviderModule.scala
@@ -21,5 +21,5 @@ import play.api.i18n.DefaultMessagesApiProvider
 
 class MessagesApiProviderModule extends AbstractModule {
   override def configure(): Unit =
-    bind(classOf[DefaultMessagesApiProvider]).to(classOf[MovementsMessagesApiProvider])
+    bind(classOf[DefaultMessagesApiProvider]).to(classOf[EccMessagesApiProvider])
 }

--- a/app/uk/gov/hmrc/customs/rosmfrontend/modules/MessagesApiProviderModule.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/modules/MessagesApiProviderModule.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.rosmfrontend.modules
+
+import com.google.inject.AbstractModule
+import play.api.i18n.DefaultMessagesApiProvider
+
+class MessagesApiProviderModule extends AbstractModule {
+  override def configure(): Unit =
+    bind(classOf[DefaultMessagesApiProvider]).to(classOf[MovementsMessagesApiProvider])
+}

--- a/app/uk/gov/hmrc/customs/rosmfrontend/modules/MovementsMessagesApiProvider.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/modules/MovementsMessagesApiProvider.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.rosmfrontend.modules
+
+import javax.inject.{Inject, Singleton}
+import play.api.http.HttpConfiguration
+import play.api.i18n.{DefaultMessagesApiProvider, Langs}
+import play.api.{Configuration, Environment}
+
+import scala.collection.breakOut
+
+@Singleton
+class MovementsMessagesApiProvider @Inject()(environment: Environment, config: Configuration, langs: Langs, httpConfiguration: HttpConfiguration)
+    extends DefaultMessagesApiProvider(environment, config, langs, httpConfiguration) {
+
+  override protected def loadAllMessages: Map[String, Map[String, String]] =
+    (langs.availables
+      .map(_.code)
+      .map { code =>
+        (code, loadMessageFiles(s".$code"))
+      }(breakOut): Map[String, Map[String, String]])
+      .+("default" -> loadMessageFiles("")) + ("default.play" -> loadMessageFiles(".default"))
+
+  private def loadMessageFiles(suffix: String): Map[String, String] =
+    config.get[Seq[String]]("messages.file.names").foldLeft(Map.empty[String, String]) {
+      case (acc, name) => acc ++ loadMessages(name + suffix)
+    }
+
+}

--- a/app/uk/gov/hmrc/customs/rosmfrontend/views/migration/what_is_your_eori.scala.html
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/views/migration/what_is_your_eori.scala.html
@@ -50,6 +50,11 @@
         <p><input class="button" type="submit" value='@uk.gov.hmrc.customs.rosmfrontend.views.helpers.subscription.ViewHelper.continueButtonText(isInReviewMode)'></p>
     }
 
+    <p>
+        @messages("cds.subscription.enter-eori-number.no-eori")
+        <a href=@uk.gov.hmrc.customs.rosmfrontend.controllers.routes.RegisterRedirectController.getEori()>@messages("cds.subscription.enter-eori-number.no-eori.link")</a>
+    </p>
+
     @helpers.helpAndSupport()
 
 </div>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -53,11 +53,11 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
 play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
+play.modules.enabled += "uk.gov.hmrc.customs.rosmfrontend.modules.MessagesApiProviderModule"
+
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
 play.http.filters = "uk.gov.hmrc.customs.rosmfrontend.filters.Filters"
-
-
 
 # Cache TTL
 cds-frontend-cache.ttl = "40minutes"
@@ -139,6 +139,7 @@ external-url {
   }
   feedback-survey = "http://localhost:9514/feedback/CDS"
   feedback-survey-subscribe = "http://localhost:9514/feedback/get-access-cds"
+  get-cds-eori = "https://www.tax.service.gov.uk/customs/register-for-cds"
 }
 
 allowlistEnabled = false
@@ -158,6 +159,9 @@ mdgNotIomCountryCodesFilename = "mdg-country-codes-not-iom.csv"
 mdgEuCountryCodesFilename = "mdg-country-codes-eu.csv"
 mdgThirdCountryCodesFilename = "mdg-country-codes-third-countries.csv"
 mdgIslandsCountryCodesFilename = "mdg-country-codes-islands.csv"
+
+messages.file.names += "messages"
+messages.file.names += "messages-ecc"
 
 microservice {
   metrics {

--- a/conf/messages-ecc.en
+++ b/conf/messages-ecc.en
@@ -1,0 +1,4 @@
+cds.subscription.enter-eori-number.page.title=What is your GB EORI number?
+cds.subscription.enter-eori-number.heading=What is your GB EORI number?
+cds.subscription.enter-eori-number.no-eori=Don't have an EORI?
+cds.subscription.enter-eori-number.no-eori.link=Register for an EORI

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -416,7 +416,6 @@ cds.subscription.nino.error.empty=Nodwch eich rhif Yswiriant Gwladol
 cds.subscription.nino.error.wrong-length=Rhaid i’r rhif Yswiriant Gwladol fod yn 9 o gymeriadau
 cds.subscription.enter-eori-number.page.title=Beth yw’ch rhif EORI?
 cds.subscription.enter-eori-number.heading=Beth yw’ch rhif EORI?
-cds.subscription.enter-eori-number.label=Beth yw’ch rhif EORI?
 cds.subscription.enter-eori-number.hint=Mae’r rhif yn dechrau gyda GB ac yna’n cael ei ddilyn gan 12 digid, er enghraifft, GB345834921000.
 cds.matching-error.eori=Nodwch rif EORI yn y fformat cywir
 cds.matching-error.eori.isEmpty=Nodwch eich rhif EORI

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -458,7 +458,6 @@ cds.subscription.nino.error.wrong-length=The National Insurance number must be 9
 #What is your Eori
 cds.subscription.enter-eori-number.page.title=What is your EORI number?
 cds.subscription.enter-eori-number.heading=What is your EORI number?
-cds.subscription.enter-eori-number.label=What is your EORI number?
 cds.subscription.enter-eori-number.hint=The number starts with GB and is then followed by 12 digits, For example, GB345834921000.
 cds.matching-error.eori=Enter an EORI number in the right format
 cds.matching-error.eori.isEmpty=Enter your EORI number

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -6,6 +6,8 @@ GET         /public/*file                                                       
 
 GET         /customs-enrolment-services/language/:lang                               @uk.gov.hmrc.customs.rosmfrontend.controllers.EoriLanguageController.switchToLanguage(lang: String)
 
+GET         /customs-enrolment-services/get-eori                                     @uk.gov.hmrc.customs.rosmfrontend.controllers.RegisterRedirectController.getEori()
+
 # enrolment-already-exists
 GET         /customs-enrolment-services/enrolment-already-exists                                      @uk.gov.hmrc.customs.rosmfrontend.controllers.EnrolmentAlreadyExistsController.enrolmentAlreadyExists
 

--- a/test/unit/controllers/RegisterRedirectControllerSpec.scala
+++ b/test/unit/controllers/RegisterRedirectControllerSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers
+
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import play.api.mvc.Result
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.customs.rosmfrontend.config.AppConfig
+import uk.gov.hmrc.customs.rosmfrontend.controllers.RegisterRedirectController
+import util.ControllerSpec
+import util.builders.SessionBuilder
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RegisterRedirectControllerSpec extends ControllerSpec with BeforeAndAfterEach {
+  private val mockAuthConnector = mock[AuthConnector]
+  private val mockAppConfig = mock[AppConfig]
+
+  private val controller =
+    new RegisterRedirectController(app, mockAuthConnector, mcc, mockAppConfig)
+
+  override def beforeEach: Unit = {
+    reset(mockAppConfig, mockAuthConnector)
+    when(mockAppConfig.externalGetEORILink).thenReturn("/some-get-eori")
+  }
+
+  "Register Redirect Controller" should {
+    "redirect to url in configuration" in {
+      getEori { result =>
+        status(result) shouldBe SEE_OTHER
+        await(result).header.headers("Location") should endWith("some-get-eori")
+      }
+    }
+  }
+
+  private def getEori(test: Future[Result] => Any) = {
+    await(test(controller.getEori().apply(SessionBuilder.buildRequestWithSessionNoUser)))
+  }
+}

--- a/test/unit/controllers/subscription/WhatIsYourEoriControllerSpec.scala
+++ b/test/unit/controllers/subscription/WhatIsYourEoriControllerSpec.scala
@@ -85,10 +85,10 @@ class WhatIsYourEoriControllerSpec
 
     assertNotLoggedInAndCdsEnrolmentChecksForSubscribe(mockAuthConnector, controller.createForm(Journey.Subscribe))
 
-    "display title as 'Enter your EORI number'" in {
+    "display title as 'What is your GB EORI number?'" in {
       showCreateForm(journey = Journey.Subscribe) { result =>
         val page = CdsPage(bodyOf(result))
-        page.title() should startWith("What is your EORI number?")
+        page.title() should startWith("What is your GB EORI number?")
       }
     }
 
@@ -135,10 +135,10 @@ class WhatIsYourEoriControllerSpec
 
     assertNotLoggedInAndCdsEnrolmentChecksForSubscribe(mockAuthConnector, controller.reviewForm(Journey.Subscribe))
 
-    "display title as 'Enter your EORI number'" in {
+    "display title as 'What is your GB EORI number'" in {
       showReviewForm() { result =>
         val page = CdsPage(bodyOf(result))
-        page.title() should startWith("What is your EORI number?")
+        page.title() should startWith("What is your GB EORI number?")
       }
     }
 

--- a/test/unit/views/subscription/WhatIsYourEoriSpec.scala
+++ b/test/unit/views/subscription/WhatIsYourEoriSpec.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.customs.rosmfrontend.forms.subscription.SubscriptionForm
 import uk.gov.hmrc.customs.rosmfrontend.models.Journey
 import uk.gov.hmrc.customs.rosmfrontend.views.html.migration.what_is_your_eori
 import util.ViewSpec
+import uk.gov.hmrc.customs.rosmfrontend.controllers._
 
 class WhatIsYourEoriSpec extends ViewSpec {
   val form: Form[EoriNumberViewModel] = SubscriptionForm.eoriNumberForm
@@ -48,10 +49,10 @@ class WhatIsYourEoriSpec extends ViewSpec {
 
   "What Is Your EORI page" should {
     "display correct title" in {
-      doc.title must startWith("What is your EORI number?")
+      doc.title must startWith("What is your GB EORI number?")
     }
     "have the correct heading text" in {
-      doc.body.getElementsByClass("heading-large").text() mustBe "What is your EORI number?"
+      doc.body.getElementsByClass("heading-large").text() mustBe "What is your GB EORI number?"
     }
     "have the correct text in the label" in {
       doc.body
@@ -60,6 +61,9 @@ class WhatIsYourEoriSpec extends ViewSpec {
     }
     "have an input of type 'text'" in {
       doc.body.getElementById("eori-number").attr("type") mustBe "text"
+    }
+    "have a link to 'Get EORI'" in {
+      doc.body.getElementsByAttributeValue("href", routes.RegisterRedirectController.getEori().url ).text() mustBe "Register for an EORI"
     }
 
     "display a field level error message when the Eori is invalid" in {


### PR DESCRIPTION
Add's a link to page for users to get an EORI
- links to existing "Get an EORI" (Register for CDS) service via an internal re-direct
- added support for multiple messages files.  New or changed message keys can be added to `messages-ecc.en` so that we should have less to translate.

TODO - add tests 