### PR TITLE
ECC-96 - content fixes

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/config/AppConfig.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.config
 
 import javax.inject.{Inject, Named, Singleton}
 import play.api.Configuration
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.play.bootstrap.config.{RunMode, ServicesConfig}
 
 import scala.concurrent.duration.{Duration, MINUTES}
@@ -47,6 +48,8 @@ class AppConfig @Inject() (
 
   private lazy val serviceIdentifierGetAccess =
     config.get[String]("microservice.services.contact-frontend.serviceIdentifierGetAccess")
+
+  def serviceReturnUrl(service: Service) = config.get[String](s"external-url.service-return.${service.name}")
 
   lazy val feedbackLink          = config.get[String]("external-url.feedback-survey")
   lazy val feedbackLinkSubscribe = config.get[String]("external-url.feedback-survey-subscribe")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/eori_enrol_success.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/eori_enrol_success.scala.html
@@ -14,11 +14,13 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName._
 
 
-@this(layout_di: layout)
+@this(layout_di: layout, appConfig: AppConfig)
 @(eori: String, service: Service)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("eds.existing-eori.enrolment.confirmation.title")) {
@@ -27,19 +29,17 @@
             <h1 id="page-heading" class="heading-xlarge">@messages("eds.existing-eori.enrolment.confirmation.title")</h1>
             <p id="eori-number" class="heading-large">@messages("cds.reg.existing.outcomes.success.eori.number") @eori</p>
         </div>
-
         <div id='additional-information'>
             <h3 class="heading-medium">@messages("cds.subscription.outcomes.steps.next")</h3>
-            <p>@messages("cds.subscription.outcomes.success.will-send-email")</p>
-            <p>
-                <a id="download-eori" href="/customs-enrolment-services/subscribe/download/pdf">@messages("cds.reg.existing.outcomes.success.download-eori.21kb")</a><br>
-                <a id="download-eori-text" href="/customs-enrolment-services/subscribe/download/text">@messages("cds.reg.existing.outcomes.success.download-eori-textfile")</a>
-            </p>
+            <p id="para1">@messages("eds.existing-eori.enrolment.confirmation.para1", messages(serviceName(service)))</p>
+
         </div>
 
         @helpers.helpAndSupport()
 
         @helpers.feedback()
+
+        <a href="@appConfig.serviceReturnUrl(service)" class="button" id="continue">@messages("cds.navigation.continue")</a>
 
     </div>
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/feedback.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/feedback.scala.html
@@ -17,5 +17,8 @@
 @()(implicit messages: Messages)
 
 <div id="what-you-think">
-    <p><a id="feedback_link" href="/feedback/CDS" target="_blank" rel="noopener noreferrer">@messages("cds.subscription.outcomes.feedback")</a></p>
+    <p>
+     <a id="feedback_link" href="/feedback/CDS" rel="noopener noreferrer">@messages("cds.subscription.outcomes.feedback")</a>
+     @messages("cds.subscription.outcomes.feedback.hint")
+    </p>
 </div>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
@@ -25,7 +25,7 @@
 @(implicit messages: Messages, request: Request[_])
 
 
-@isLoggedIn = @{ !request.session.isEmpty }
+@isLoggedIn = @{!request.session.isEmpty && request.session.get("authToken").isDefined}
 
 @journeyHeading = @{
     if(request.path.contains("/register")) {
@@ -84,6 +84,8 @@
     </div>
 
     @language_selection(languageMap, routeToSwitchLanguage, Some("language-toggle"), Some("eori-common-component-frontend"))
+
+    @request.session
 
 </div>
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
@@ -25,7 +25,7 @@
 @(implicit messages: Messages, request: Request[_])
 
 
-@isLoggedIn = @{!request.session.isEmpty && request.session.get("userId").isDefined}
+@isLoggedIn = @{ true || !request.session.isEmpty && request.session.get("userId").isDefined}
 
 @journeyHeading = @{
     if(request.path.contains("/register")) {

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
@@ -85,8 +85,6 @@
 
     @language_selection(languageMap, routeToSwitchLanguage, Some("language-toggle"), Some("eori-common-component-frontend"))
 
-    @request.session
-
 </div>
 
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/partials/header.scala.html
@@ -25,7 +25,7 @@
 @(implicit messages: Messages, request: Request[_])
 
 
-@isLoggedIn = @{ true || !request.session.isEmpty && request.session.get("userId").isDefined}
+@isLoggedIn = @{ !request.session.isEmpty }
 
 @journeyHeading = @{
     if(request.path.contains("/register")) {

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/registration_exists.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/registration_exists.scala.html
@@ -17,9 +17,10 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.serviceName
+@import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
 
 
-@this(layout_di: layout)
+@this(layout_di: layout, appConfig: AppConfig)
 @(service: Service)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("cds.enrolment.already.exists.title")) {
@@ -29,7 +30,7 @@
 
         <p id="para1">@messages("cds.enrolment.already.exists.para1", serviceName(service))</p>
 
-        <a href="/todo" id="continue">@messages("cds.enrolment.already.exists.continue", serviceName(service)) </a>
+        <a href="@appConfig.serviceReturnUrl(service)" id="continue">@messages("cds.enrolment.already.exists.continue", serviceName(service)) </a>
 
         @helpers.helpAndSupport()
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,6 +137,9 @@ external-url {
     continue-url-subscribe = "http://localhost:6750/customs-enrolment-services/subscribe/are-you-based-in-uk"
     continue-url-subscribe-from-are-you-based-in-uk = "http://localhost:6750/customs-enrolment-services/subscribe/subscribe"
   }
+  service-return {
+    atar="https://www.gov.uk"
+  }
   feedback-survey = "http://localhost:9514/feedback/CDS"
   feedback-survey-subscribe = "http://localhost:9514/feedback/get-access-cds"
   get-cds-eori = "http://localhost:9830/customs/register-for-cds"

--- a/conf/messages-ecc.cy
+++ b/conf/messages-ecc.cy
@@ -19,7 +19,6 @@ cds.service.friendly.name.atar=TRANSLATE Advance Tariff Rulings
 
 eds.existing-eori.enrolment.confirmation.title=TRANSLATE Application complete
 eds.existing-eori.enrolment.confirmation.heading=TRANSLATE Application complete
-eds.existing-eori.enrolment.confirmation.heading=TRANSLATE Application complete
 eds.existing-eori.enrolment.confirmation.para1=TRANSLATE You are now enrolled to the {0} service.
 
 cds.subscription.outcomes.feedback=TRANSLATE What did you think of this service?

--- a/conf/messages-ecc.cy
+++ b/conf/messages-ecc.cy
@@ -19,3 +19,8 @@ cds.service.friendly.name.atar=TRANSLATE Advance Tariff Rulings
 
 eds.existing-eori.enrolment.confirmation.title=TRANSLATE Application complete
 eds.existing-eori.enrolment.confirmation.heading=TRANSLATE Application complete
+eds.existing-eori.enrolment.confirmation.heading=TRANSLATE Application complete
+eds.existing-eori.enrolment.confirmation.para1=TRANSLATE You are now enrolled to the {0} service.
+
+cds.subscription.outcomes.feedback=TRANSLATE What did you think of this service?
+cds.subscription.outcomes.feedback.hint=TRANSLATE (takes 30 seconds) 

--- a/conf/messages-ecc.en
+++ b/conf/messages-ecc.en
@@ -19,3 +19,7 @@ cds.service.friendly.name.atar=Advance Tariff Rulings
 
 eds.existing-eori.enrolment.confirmation.title=Application complete
 eds.existing-eori.enrolment.confirmation.heading=Application complete
+eds.existing-eori.enrolment.confirmation.para1=You are now enrolled to the {0} service.
+
+cds.subscription.outcomes.feedback=What did you think of this service?
+cds.subscription.outcomes.feedback.hint=(takes 30 seconds)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -9,12 +9,12 @@ GET         /customs-enrolment-services/language/:lang                          
 GET         /customs-enrolment-services/get-eori                                     @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.RegisterRedirectController.getEori()
 
 # enrolment-already-exists
-GET         /customs-enrolment-services/:service/enrolment-already-exists                      @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(service: Service)
+GET         /customs-enrolment-services/:service/subscribe/enrolment-already-exists                      @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(service: Service)
 
 # check-existing-eori
-GET         /customs-enrolment-services/:service/check-existing-eori                           @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.HasExistingEoriController.displayPage(service: Service)
-POST        /customs-enrolment-services/:service/check-existing-eori                           @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.HasExistingEoriController.enrol(service: Service)
-GET         /customs-enrolment-services/:service/check-existing-eori/confirmation              @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.HasExistingEoriController.enrolSuccess(service: Service)
+GET         /customs-enrolment-services/:service/subscribe/check-existing-eori                           @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.HasExistingEoriController.displayPage(service: Service)
+POST        /customs-enrolment-services/:service/subscribe/check-existing-eori                           @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.HasExistingEoriController.enrol(service: Service)
+GET         /customs-enrolment-services/:service/subscribe/check-existing-eori/confirmation              @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.HasExistingEoriController.enrolSuccess(service: Service)
 
 GET         /customs-enrolment-services/:journey/display-sign-out                                     @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.SecuritySignOutController.displayPage(journey: Journey.Value)
 GET         /customs-enrolment-services/:journey/sign-out                                             @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.SecuritySignOutController.signOut(journey: Journey.Value)

--- a/test/unit/config/AppConfigSpec.scala
+++ b/test/unit/config/AppConfigSpec.scala
@@ -18,6 +18,7 @@ package unit.config
 
 import java.util.concurrent.TimeUnit
 
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import util.ControllerSpec
 
 import scala.concurrent.duration.Duration
@@ -105,6 +106,10 @@ class AppConfigSpec extends ControllerSpec {
 
     "have reportAProblemNonJSUrl defined for subscribe" in {
       appConfig.reportAProblemNonJSUrlGetAccess shouldBe "http://localhost:9250/contact/problem_reports_nonjs?service=get-access-cds"
+    }
+
+    "have service url for ATaR defined" in {
+      appConfig.serviceReturnUrl(Service.ATaR) shouldBe "https://www.gov.uk"
     }
   }
 

--- a/test/unit/controllers/subscription/Sub02ControllerGetAnEoriSpec.scala
+++ b/test/unit/controllers/subscription/Sub02ControllerGetAnEoriSpec.scala
@@ -323,9 +323,9 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
                 |You should only share it with trusted business partners or approved customs representatives. For example, you should give it to your courier or freight forwarder. They will use it to make customs declarations on your behalf.
                 | """)
           page.elementIsPresent(RegistrationCompletePage.LeaveFeedbackLinkXpath) shouldBe true
-          page.getElementsText(
-            RegistrationCompletePage.LeaveFeedbackLinkXpath
-          ) shouldBe "What did you think of this service? (opens in a new window or tab)"
+          page.getElementsText(RegistrationCompletePage.LeaveFeedbackLinkXpath) should include(
+            "What did you think of this service?"
+          )
           page.getElementsHref(RegistrationCompletePage.LeaveFeedbackLinkXpath) shouldBe "/feedback/CDS"
       }
     }

--- a/test/unit/controllers/subscription/Sub02ControllerRegisterExistingSpec.scala
+++ b/test/unit/controllers/subscription/Sub02ControllerRegisterExistingSpec.scala
@@ -165,9 +165,9 @@ class Sub02ControllerRegisterExistingSpec extends ControllerSpec with BeforeAndA
           )
 
           page.elementIsPresent(RegistrationCompletePage.LeaveFeedbackLinkXpath) shouldBe true
-          page.getElementsText(
-            RegistrationCompletePage.LeaveFeedbackLinkXpath
-          ) shouldBe "What did you think of this service? (opens in a new window or tab)"
+          page.getElementsText(RegistrationCompletePage.LeaveFeedbackLinkXpath) should include(
+            "What did you think of this service?"
+          )
           page.getElementsHref(RegistrationCompletePage.LeaveFeedbackLinkXpath) shouldBe "/feedback/CDS"
       }
     }

--- a/test/unit/views/EoriEnrolSuccessSpec.scala
+++ b/test/unit/views/EoriEnrolSuccessSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.views
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.test.FakeRequest
+import play.api.test.Helpers.contentAsString
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName._
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.eori_enrol_success
+import util.ViewSpec
+
+class EoriEnrolSuccessSpec extends ViewSpec {
+
+  implicit val request = withFakeCSRF(FakeRequest())
+
+  private val service = Service.ATaR
+  private val eori    = "GB234532132435"
+
+  private val view = app.injector.instanceOf[eori_enrol_success]
+
+  "EORI Enrol Success Page" should {
+
+    "display correct title" in {
+      doc.title must startWith("Application complete")
+    }
+
+    "display correct heading" in {
+      doc.getElementsByTag("h1").text() must startWith("Application complete")
+    }
+
+    "display eori" in {
+      doc.body.getElementById("eori-number").text mustBe s"EORI number: $eori"
+    }
+
+    "display correct service name" in {
+      doc.body.getElementById("para1").text() must include(serviceName(service))
+    }
+
+  }
+
+  private lazy val doc: Document = Jsoup.parse(contentAsString(view(eori, service)))
+}

--- a/test/unit/views/partials/HeaderSpec.scala
+++ b/test/unit/views/partials/HeaderSpec.scala
@@ -30,11 +30,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class HeaderSpec extends ControllerSpec {
 
-  private val mockAuthConnector = mock[AuthConnector]
+  private val mockAuthConnector    = mock[AuthConnector]
   private val mockCdsFrontendCache = mock[SessionCache]
 
-  private val viewStart = app.injector.instanceOf[start]
-  private val migrationStart = app.injector.instanceOf[migration_start]
+  private val viewStart                  = app.injector.instanceOf[start]
+  private val migrationStart             = app.injector.instanceOf[migration_start]
   private val accessibilityStatementView = app.injector.instanceOf[accessibility_statement]
 
   private val controller = new ApplicationController(

--- a/test/unit/views/partials/HeaderSpec.scala
+++ b/test/unit/views/partials/HeaderSpec.scala
@@ -16,6 +16,7 @@
 
 package unit.views.partials
 
+import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.ApplicationController
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
@@ -29,11 +30,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class HeaderSpec extends ControllerSpec {
 
-  private val mockAuthConnector    = mock[AuthConnector]
+  private val mockAuthConnector = mock[AuthConnector]
   private val mockCdsFrontendCache = mock[SessionCache]
 
-  private val viewStart                  = app.injector.instanceOf[start]
-  private val migrationStart             = app.injector.instanceOf[migration_start]
+  private val viewStart = app.injector.instanceOf[start]
+  private val migrationStart = app.injector.instanceOf[migration_start]
   private val accessibilityStatementView = app.injector.instanceOf[accessibility_statement]
 
   private val controller = new ApplicationController(
@@ -59,9 +60,7 @@ class HeaderSpec extends ControllerSpec {
     }
 
     "not be present when a user isn't logged in" in {
-      AuthBuilder.withNotLoggedInUser(mockAuthConnector)
-
-      val result = controller.start().apply(SessionBuilder.buildRequestWithSessionNoUser)
+      val result = controller.start().apply(FakeRequest())
 
       val page = CdsPage(bodyOf(result))
       page.elementIsPresent("//a[@id='sign-out']") shouldBe false

--- a/test/unit/views/partials/HeaderSpec.scala
+++ b/test/unit/views/partials/HeaderSpec.scala
@@ -16,7 +16,6 @@
 
 package unit.views.partials
 
-import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.ApplicationController
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
@@ -60,7 +59,9 @@ class HeaderSpec extends ControllerSpec {
     }
 
     "not be present when a user isn't logged in" in {
-      val result = controller.start().apply(FakeRequest())
+      AuthBuilder.withNotLoggedInUser(mockAuthConnector)
+
+      val result = controller.start().apply(SessionBuilder.buildRequestWithSessionNoUser)
 
       val page = CdsPage(bodyOf(result))
       page.elementIsPresent("//a[@id='sign-out']") shouldBe false

--- a/test/unit/views/subscription/Reg06EoriAlreadyLinkedSpec.scala
+++ b/test/unit/views/subscription/Reg06EoriAlreadyLinkedSpec.scala
@@ -63,7 +63,7 @@ class Reg06EoriAlreadyLinkedSpec extends ViewSpec {
     "have the feedback link" in {
       doc
         .getElementById("what-you-think")
-        .text() mustBe "What did you think of this service? (opens in a new window or tab)"
+        .text() must include("What did you think of this service?")
       doc.getElementById("feedback_link").attributes().get("href").mustBe("/feedback/CDS")
     }
   }

--- a/test/unit/views/subscription/Sub02EoriAlreadyAssociatedSpec.scala
+++ b/test/unit/views/subscription/Sub02EoriAlreadyAssociatedSpec.scala
@@ -55,7 +55,7 @@ class Sub02EoriAlreadyAssociatedSpec extends ViewSpec {
     "have the feedback link" in {
       doc
         .getElementById("what-you-think")
-        .text() mustBe "What did you think of this service? (opens in a new window or tab)"
+        .text() must include("What did you think of this service?")
       doc.getElementById("feedback_link").attributes().get("href").mustBe("/feedback/CDS")
     }
   }

--- a/test/unit/views/subscription/Sub02SubscriptionInProgressSpec.scala
+++ b/test/unit/views/subscription/Sub02SubscriptionInProgressSpec.scala
@@ -60,7 +60,7 @@ class Sub02SubscriptionInProgressSpec extends ViewSpec {
     "have the feedback link" in {
       doc
         .getElementById("what-you-think")
-        .text() mustBe "What did you think of this service? (opens in a new window or tab)"
+        .text() must include("What did you think of this service?")
       doc.getElementById("feedback_link").attributes().get("href").mustBe("/feedback/CDS")
     }
   }

--- a/test/util/builders/SessionBuilder.scala
+++ b/test/util/builders/SessionBuilder.scala
@@ -26,16 +26,16 @@ import uk.gov.hmrc.http.SessionKeys
 
 object SessionBuilder {
 
-  def sessionMap(userId: String): List[(String, String)] = {
+  def sessionMap(authToken: String): List[(String, String)] = {
     val sessionId = s"session-${UUID.randomUUID}"
-    List(SessionKeys.sessionId -> sessionId, SessionKeys.userId -> userId)
+    List(SessionKeys.sessionId -> sessionId, SessionKeys.authToken -> authToken)
   }
 
   def addToken[T](fakeRequest: FakeRequest[T])(implicit app: Application): FakeRequest[T] =
     new FakeRequest(CSRFTokenHelper.addCSRFToken(fakeRequest))
 
-  def buildRequestWithSession(userId: String)(implicit app: Application) =
-    addToken(FakeRequest().withSession(sessionMap(userId): _*))
+  def buildRequestWithSession(authtoken: String)(implicit app: Application) =
+    addToken(FakeRequest().withSession(sessionMap(authtoken): _*))
 
   def buildRequestWithSessionAndFormValues(userId: String, form: Map[String, String])(implicit
     app: Application
@@ -67,19 +67,21 @@ object SessionBuilder {
     FakeRequest(method, path).withSession(SessionKeys.sessionId -> sessionId, "visited-uk-page" -> "true")
   }
 
-  def buildRequestWithSessionAndPath(path: String, userId: String, method: String = "GET")(implicit app: Application) =
-    FakeRequest(method, path).withSession(sessionMap(userId): _*)
+  def buildRequestWithSessionAndPath(path: String, authToken: String, method: String = "GET")(implicit
+    app: Application
+  ) =
+    FakeRequest(method, path).withSession(sessionMap(authToken): _*)
 
   def buildRequestWithSessionAndPathAndFormValues(
     method: String,
     path: String,
-    userId: String,
+    authToken: String,
     form: Map[String, String]
   )(implicit app: Application): FakeRequest[AnyContentAsFormUrlEncoded] =
-    FakeRequest(method, path).withSession(sessionMap(userId): _*).withFormUrlEncodedBody(form.toList: _*)
+    FakeRequest(method, path).withSession(sessionMap(authToken): _*).withFormUrlEncodedBody(form.toList: _*)
 
-  def buildRequestWithSessionAndOrgType(userId: String, orgTypeId: String)(implicit app: Application) = {
-    val list    = (RequestSessionDataKeys.selectedOrganisationType -> orgTypeId) :: sessionMap(userId)
+  def buildRequestWithSessionAndOrgType(authToken: String, orgTypeId: String)(implicit app: Application) = {
+    val list    = (RequestSessionDataKeys.selectedOrganisationType -> orgTypeId) :: sessionMap(authToken)
     val request = FakeRequest().withSession(list: _*)
     addToken(request)
   }


### PR DESCRIPTION
- Header and sign-out link for 'check_existing_eori' and 'confirmation'
- Fix content for 'confirmation' with prototype
- Add Continue button/link to 'confirmation' and 'enrolment-already-exists'