### PR TITLE
ECC-11 - changes to support new email templates

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/SubscriptionRecoveryController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/SubscriptionRecoveryController.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration
 
 import javax.inject.{Inject, Singleton}
 import play.api.Application
+import play.api.i18n.Messages
 import play.api.mvc.{Action, _}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.connector.SUB09SubscriptionDisplayConnector
@@ -67,9 +68,9 @@ class SubscriptionRecoveryController @Inject() (
         customId <- if (isRow) cachedCustomsIdF else Future.successful(None)
       } yield (journey, isRow, customId) match {
         case (Journey.Subscribe, true, Some(_)) => subscribeForCDS(service)    // UK journey
-        case (Journey.Subscribe, true, None)    => subscribeForCDSROW(service) //subscribeForCDSROW //ROW
-        case (Journey.Subscribe, false, _)      => subscribeForCDS(service)    //UK Journey
-        case _                                  => subscribeGetAnEori(service) //Journey Get An EORI
+        case (Journey.Subscribe, true, None)    => subscribeForCDSROW(service) // subscribeForCDSROW //ROW
+        case (Journey.Subscribe, false, _)      => subscribeForCDS(service)    // UK Journey
+        case _                                  => subscribeGetAnEori(service) // Journey Get An EORI
       }
       result.flatMap(identity)
   }
@@ -176,7 +177,7 @@ class SubscriptionRecoveryController @Inject() (
     subscriptionDisplayResponse: SubscriptionDisplayResponse,
     service: Service,
     journey: Journey.Value
-  )(redirect: => Result)(implicit headerCarrier: HeaderCarrier): Future[Result] = {
+  )(redirect: => Result)(implicit headerCarrier: HeaderCarrier, messages: Messages): Future[Result] = {
     val formBundleId =
       subscriptionDisplayResponse.responseCommon.returnParameters
         .flatMap(_.find(_.paramName.equals("ETMPFORMBUNDLENUMBER")).map(_.paramValue))

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/RecipientDetails.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/RecipientDetails.scala
@@ -16,16 +16,20 @@
 
 package uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription
 
+import play.api.i18n.Messages
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Journey, Service}
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName
 
 case class RecipientDetails(
   journey: Journey.Value,
   service: String,
+  serviceName: String,
   recipientEmailAddress: String,
   recipientFullName: String,
   orgName: Option[String],
-  completionDate: Option[String] = None
+  completionDate: Option[String] = None,
+  languageCode: Option[String] = None
 )
 
 object RecipientDetails {
@@ -38,17 +42,30 @@ object RecipientDetails {
     recipientFullName: String,
     orgName: Option[String],
     completionDate: Option[String]
-  ): RecipientDetails =
-    new RecipientDetails(journey, service.name, recipientEmailAddress, recipientFullName, orgName, completionDate)
+  )(implicit messages: Messages): RecipientDetails =
+    new RecipientDetails(
+      journey,
+      service.name,
+      ServiceName.serviceName(service),
+      recipientEmailAddress,
+      recipientFullName,
+      orgName,
+      completionDate,
+      Some(messages.lang.code)
+    )
 
-  def apply(service: Service, journey: Journey.Value, contactDetails: ContactDetails): RecipientDetails =
+  def apply(service: Service, journey: Journey.Value, contactDetails: ContactDetails)(implicit
+    messages: Messages
+  ): RecipientDetails =
     RecipientDetails(
       journey,
       service.name,
+      ServiceName.serviceName(service),
       contactDetails.emailAddress,
       contactDetails.fullName,
       orgName = None,
-      completionDate = None
+      completionDate = None,
+      Some(messages.lang.code)
     )
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/RecipientDetails.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/RecipientDetails.scala
@@ -43,7 +43,7 @@ object RecipientDetails {
     orgName: Option[String],
     completionDate: Option[String]
   )(implicit messages: Messages): RecipientDetails =
-    new RecipientDetails(
+    RecipientDetails(
       journey,
       service.name,
       ServiceName.serviceName(service),

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/CdsSubscriber.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/CdsSubscriber.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription
 
 import javax.inject.{Inject, Singleton}
+import play.api.i18n.Messages
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
@@ -24,6 +25,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{RecipientDe
 import uk.gov.hmrc.eoricommoncomponent.frontend.logging.CdsLogger
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Journey, Service}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -41,7 +43,7 @@ class CdsSubscriber @Inject() (
     cdsOrganisationType: Option[CdsOrganisationType],
     service: Service,
     journey: Journey.Value
-  )(implicit hc: HeaderCarrier, request: Request[AnyContent]): Future[SubscriptionResult] = {
+  )(implicit hc: HeaderCarrier, request: Request[AnyContent], messages: Messages): Future[SubscriptionResult] = {
     def migrationEoriUK: Future[SubscriptionResult] =
       for {
         subscriptionDetailsHolder <- sessionCache.subscriptionDetails
@@ -130,7 +132,7 @@ class CdsSubscriber @Inject() (
     registrationDetails: RegistrationDetails,
     subscriptionDetails: Option[SubscriptionDetails],
     service: Service
-  )(implicit hc: HeaderCarrier): Future[Unit] = {
+  )(implicit hc: HeaderCarrier, messages: Messages): Future[Unit] = {
 
     val sapNumber = registrationDetails.sapNumber
     val safeId    = registrationDetails.safeId
@@ -190,7 +192,7 @@ class CdsSubscriber @Inject() (
     subDetails: SubscriptionDetails,
     email: String,
     service: Service
-  )(implicit hc: HeaderCarrier): Future[Unit] = {
+  )(implicit hc: HeaderCarrier, messages: Messages): Future[Unit] = {
 
     val completionDate = subscriptionResult match {
       case success: SubscriptionSuccessful => Some(success.processingDate)
@@ -225,7 +227,7 @@ class CdsSubscriber @Inject() (
     subDetails: SubscriptionDetails,
     email: String,
     service: Service
-  )(implicit hc: HeaderCarrier): Future[Unit] = {
+  )(implicit hc: HeaderCarrier, messages: Messages): Future[Unit] = {
 
     val taxPayerId  = regDetails.responseDetail.flatMap(_.responseData.map(r => TaxPayerId(r.SAFEID)))
     val contactName = regDetails.responseDetail.flatMap(_.responseData.flatMap(_.contactDetail.map(_.contactName)))
@@ -246,7 +248,14 @@ class CdsSubscriber @Inject() (
         val orgName = Some(subDetails.name)
         callHandle(
           subscriptionResult,
-          RecipientDetails(service, Journey.Subscribe, email, name.getOrElse(""), orgName, completionDate),
+          RecipientDetails(
+            service,
+            Journey.Subscribe,
+            email,
+            name.getOrElse(""),
+            orgName,
+            completionDate
+          ),
           id,
           subDetails.eoriNumber.map(Eori),
           SafeId(id.id)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/CdsSubscriber.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/CdsSubscriber.scala
@@ -248,14 +248,7 @@ class CdsSubscriber @Inject() (
         val orgName = Some(subDetails.name)
         callHandle(
           subscriptionResult,
-          RecipientDetails(
-            service,
-            Journey.Subscribe,
-            email,
-            name.getOrElse(""),
-            orgName,
-            completionDate
-          ),
+          RecipientDetails(service, Journey.Subscribe, email, name.getOrElse(""), orgName, completionDate),
           id,
           subDetails.eoriNumber.map(Eori),
           SafeId(id.id)

--- a/test/base/Injector.scala
+++ b/test/base/Injector.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import com.codahale.metrics.SharedMetricRegistries
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.reflect.ClassTag
+
+trait Injector {
+
+  /**
+    * Clearing shared metrics registries to avoid `A metric named jvm.attribute.vendor already exists` error.
+    *
+    * It appears very often with places with injector. This is enough solution for this problem.
+    *
+    * Reference and other solutions: https://github.com/kenshoo/metrics-play/issues/74
+    */
+  SharedMetricRegistries.clear()
+
+  private val injector = GuiceApplicationBuilder().injector()
+
+  def instanceOf[T <: AnyRef](implicit classTag: ClassTag[T]): T = injector.instanceOf[T]
+}

--- a/test/integration/HandleSubscriptionConnectorSpec.scala
+++ b/test/integration/HandleSubscriptionConnectorSpec.scala
@@ -68,6 +68,7 @@ class HandleSubscriptionConnectorSpec extends IntegrationTestsSpec with ScalaFut
         |        "recipientDetails": {
         |            "journey" : "Register",
         |            "service" : "ATaR",
+        |            "serviceName" : "Advance Tariff Rulings",
         |            "recipientFullName": "John Doe",
         |            "recipientEmailAddress": "john.doe@example.com",
         |            "orgName": "orgName",

--- a/test/unit/controllers/registration/RegisterWithEoriAndIdControllerSpec.scala
+++ b/test/unit/controllers/registration/RegisterWithEoriAndIdControllerSpec.scala
@@ -23,6 +23,7 @@ import org.joda.time.{DateTime, LocalDate}
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.{Assertion, BeforeAndAfterEach}
+import play.api.i18n.Messages
 import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
@@ -189,7 +190,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -247,7 +248,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           meq(Some(CdsOrganisationType.SoleTrader)),
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -290,7 +291,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           meq(Some(CdsOrganisationType.SoleTrader)),
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -339,7 +340,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           meq(Some(CdsOrganisationType.Individual)),
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -365,7 +366,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -425,7 +426,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           meq(Some(CdsOrganisationType.SoleTrader)),
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -453,7 +454,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionPending(formBundleIdResponse, processingDateResponse, Some(emailVerificationTimestamp))
@@ -519,7 +520,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -579,7 +580,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -619,7 +620,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -663,7 +664,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -707,7 +708,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionFailed(
@@ -746,7 +747,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -779,7 +780,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -815,7 +816,7 @@ class RegisterWithEoriAndIdControllerSpec extends ControllerSpec with BeforeAndA
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(

--- a/test/unit/controllers/subscription/Sub02ControllerGetAnEoriSpec.scala
+++ b/test/unit/controllers/subscription/Sub02ControllerGetAnEoriSpec.scala
@@ -27,7 +27,7 @@ import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.connector.PdfGeneratorConnector
-import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.{Sub02Controller, routes}
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.{routes, Sub02Controller}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.SubscriptionCreateResponse._
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Journey, Service}
@@ -166,7 +166,8 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
         await(result)
         verify(mockCdsSubscriber).subscribeWithCachedDetails(meq(None), meq(Service.ATaR), meq(Journey.Register))(
           any[HeaderCarrier],
-          any[Request[AnyContent]], any[Messages]
+          any[Request[AnyContent]],
+          any[Messages]
         )
       }
     }

--- a/test/unit/controllers/subscription/Sub02ControllerGetAnEoriSpec.scala
+++ b/test/unit/controllers/subscription/Sub02ControllerGetAnEoriSpec.scala
@@ -22,11 +22,12 @@ import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
+import play.api.i18n.Messages
 import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.connector.PdfGeneratorConnector
-import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.{routes, Sub02Controller}
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.{Sub02Controller, routes}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.SubscriptionCreateResponse._
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Journey, Service}
@@ -123,7 +124,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -140,7 +141,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           meq(Some(mockCdsOrganisationType)),
           meq(Service.ATaR),
           meq(Journey.Register)
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       }
     }
 
@@ -150,7 +151,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -165,7 +166,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
         await(result)
         verify(mockCdsSubscriber).subscribeWithCachedDetails(meq(None), meq(Service.ATaR), meq(Journey.Register))(
           any[HeaderCarrier],
-          any[Request[AnyContent]]
+          any[Request[AnyContent]], any[Messages]
         )
       }
     }
@@ -176,7 +177,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(
           SubscriptionSuccessful(
@@ -200,7 +201,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(
         Future.successful(SubscriptionPending(formBundleIdResponse, processingDate, Some(emailVerificationTimestamp)))
       )
@@ -217,7 +218,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(Future.successful(SubscriptionFailed("Subscription application has been rejected", processingDate)))
 
       subscribeForGetYourEORI() { result =>
@@ -232,7 +233,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(Future.successful(SubscriptionFailed(EoriAlreadyExists, processingDate)))
 
       subscribeForGetYourEORI() { result =>
@@ -247,7 +248,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(Future.successful(SubscriptionFailed(EoriAlreadyAssociated, processingDate)))
 
       subscribeForGetYourEORI() { result =>
@@ -262,7 +263,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(Future.successful(SubscriptionFailed(SubscriptionInProgress, processingDate)))
 
       subscribeForGetYourEORI() { result =>
@@ -277,7 +278,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(Future.successful(SubscriptionFailed(RequestNotProcessed, processingDate)))
 
       subscribeForGetYourEORI() { result =>
@@ -296,7 +297,7 @@ class Sub02ControllerGetAnEoriSpec extends ControllerSpec with BeforeAndAfterEac
           any[Option[CdsOrganisationType]],
           any[Service],
           any[Journey.Value]
-        )(any[HeaderCarrier], any[Request[AnyContent]])
+        )(any[HeaderCarrier], any[Request[AnyContent]], any[Messages])
       ).thenReturn(Future.failed(emulatedFailure))
 
       val caught = intercept[Exception] {

--- a/test/unit/services/subscription/CdsSubscriberSpec.scala
+++ b/test/unit/services/subscription/CdsSubscriberSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
+import play.api.i18n.Messages
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.SubscriptionFlowManager
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
@@ -61,6 +62,7 @@ class CdsSubscriberSpec extends UnitSpec with MockitoSugar with ScalaFutures wit
 
   implicit private val hc: HeaderCarrier                = mock[HeaderCarrier]
   implicit private val mockRequest: Request[AnyContent] = mock[Request[AnyContent]]
+  implicit private val mockMessages: Messages = mock[Messages]
 
   private val eori                       = "EORI-Number"
   private val formBundleId               = "Form-Bundle-Id"

--- a/test/unit/services/subscription/CdsSubscriberSpec.scala
+++ b/test/unit/services/subscription/CdsSubscriberSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.services.subscription
 
-import base.UnitSpec
+import base.{Injector, UnitSpec}
 import common.support.testdata.TestData
 import common.support.testdata.subscription.SubscriptionContactDetailsBuilder
 import org.joda.time.DateTime
@@ -28,7 +28,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import play.api.i18n.Lang.defaultLang
 import play.api.i18n.{Messages, MessagesApi, MessagesImpl}
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.SubscriptionFlowManager
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
@@ -45,7 +44,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class CdsSubscriberSpec extends UnitSpec with MockitoSugar with ScalaFutures with BeforeAndAfterEach {
+class CdsSubscriberSpec extends UnitSpec with MockitoSugar with ScalaFutures with BeforeAndAfterEach with Injector {
 
   implicit override val patienceConfig =
     PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(15, Millis)))
@@ -63,9 +62,7 @@ class CdsSubscriberSpec extends UnitSpec with MockitoSugar with ScalaFutures wit
   implicit private val hc: HeaderCarrier                = mock[HeaderCarrier]
   implicit private val mockRequest: Request[AnyContent] = mock[Request[AnyContent]]
 
-  private val injector                  = GuiceApplicationBuilder().injector()
-  implicit val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
-  implicit val messages: Messages       = MessagesImpl(defaultLang, messagesApi)
+  implicit val messages: Messages = MessagesImpl(defaultLang, instanceOf[MessagesApi])
 
   private val eori                       = "EORI-Number"
   private val formBundleId               = "Form-Bundle-Id"

--- a/test/unit/services/subscription/CdsSubscriberSpec.scala
+++ b/test/unit/services/subscription/CdsSubscriberSpec.scala
@@ -26,7 +26,9 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
-import play.api.i18n.Messages
+import play.api.i18n.Lang.defaultLang
+import play.api.i18n.{Messages, MessagesApi, MessagesImpl}
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.SubscriptionFlowManager
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
@@ -45,8 +47,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class CdsSubscriberSpec extends UnitSpec with MockitoSugar with ScalaFutures with BeforeAndAfterEach {
 
-//  override implicit def patienceConfig: PatienceConfig =
-//    super.patienceConfig.copy(timeout = Span(defaultTimeout.toMillis, Millis))
   implicit override val patienceConfig =
     PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(15, Millis)))
 
@@ -62,7 +62,10 @@ class CdsSubscriberSpec extends UnitSpec with MockitoSugar with ScalaFutures wit
 
   implicit private val hc: HeaderCarrier                = mock[HeaderCarrier]
   implicit private val mockRequest: Request[AnyContent] = mock[Request[AnyContent]]
-  implicit private val mockMessages: Messages = mock[Messages]
+
+  private val injector                  = GuiceApplicationBuilder().injector()
+  implicit val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
+  implicit val messages: Messages       = MessagesImpl(defaultLang, messagesApi)
 
   private val eori                       = "EORI-Number"
   private val formBundleId               = "Form-Bundle-Id"

--- a/test/unit/services/subscription/HandleSubscriptionServiceSpec.scala
+++ b/test/unit/services/subscription/HandleSubscriptionServiceSpec.scala
@@ -45,8 +45,11 @@ class HandleSubscriptionServiceSpec extends UnitSpec with MockitoSugar with Befo
     reset(mockHandleSubscriptionConnector)
   }
 
-  val formBundleId: String                         = "formBundleId"
-  val recipientDetails: RecipientDetails           = RecipientDetails(Journey.Register, Service.ATaR.name, "Advance Tariff Rulings", "", "", None, None)
+  val formBundleId: String = "formBundleId"
+
+  val recipientDetails: RecipientDetails =
+    RecipientDetails(Journey.Register, Service.ATaR.name, "Advance Tariff Rulings", "", "", None, None)
+
   val sapNumber: TaxPayerId                        = TaxPayerId("id")
   val eori: Option[Eori]                           = Some(Eori("eori"))
   val emailVerificationTimestamp: Option[DateTime] = Some(TestData.emailVerificationTimestamp)

--- a/test/unit/services/subscription/HandleSubscriptionServiceSpec.scala
+++ b/test/unit/services/subscription/HandleSubscriptionServiceSpec.scala
@@ -46,7 +46,7 @@ class HandleSubscriptionServiceSpec extends UnitSpec with MockitoSugar with Befo
   }
 
   val formBundleId: String                         = "formBundleId"
-  val recipientDetails: RecipientDetails           = RecipientDetails(Service.ATaR, Journey.Register, "", "", None, None)
+  val recipientDetails: RecipientDetails           = RecipientDetails(Journey.Register, Service.ATaR.name, "Advance Tariff Rulings", "", "", None, None)
   val sapNumber: TaxPayerId                        = TaxPayerId("id")
   val eori: Option[Eori]                           = Some(Eori("eori"))
   val emailVerificationTimestamp: Option[DateTime] = Some(TestData.emailVerificationTimestamp)


### PR DESCRIPTION
This PR adds a friendly service name and users language to the RecipientDetails object persisted to mongo.