### PR TITLE
BAU prevent user going back from auto-enrol confirmation

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ApplicationController.scala
@@ -64,8 +64,6 @@ class ApplicationController @Inject() (
           }
        
       }.recover {
-        case SpecificEnrolmentExists(service) =>
-          Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(service))
         case SpecificGroupIdEnrolmentExists(service) =>
           Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExistsForGroup(service))
       }
@@ -118,9 +116,6 @@ class ApplicationController @Inject() (
   }
 
 }
-
-case class SpecificEnrolmentExists(service: Service)
-    extends Exception(s"User has already enrolment for ${service.code}")
 
 case class SpecificGroupIdEnrolmentExists(service: Service)
     extends Exception(s"Group Id has enrolment to ${service.code}")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ApplicationController.scala
@@ -70,7 +70,6 @@ class ApplicationController @Inject() (
         case SpecificEnrolmentExists(service) =>
           Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(service))
         case SpecificGroupIdEnrolmentExists(service) =>
-          // Below redirect should be to page that doesn't exists yet
           Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExistsForGroup(service))
       }
   }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EnrolmentAlreadyExistsController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EnrolmentAlreadyExistsController.scala
@@ -35,14 +35,16 @@ class EnrolmentAlreadyExistsController @Inject() (
   mcc: MessagesControllerComponents
 ) extends FrontendController(mcc) with I18nSupport {
 
+  // Note: permitted for user with service enrolment
   def enrolmentAlreadyExists(service: Service): Action[AnyContent] =
-    authAction.ggAuthorisedUserWithEnrolmentsAction {
+    authAction.ggAuthorisedUserWithServiceAction {
       implicit request => _: LoggedInUserWithEnrolments =>
         Future.successful(Ok(registrationExistsView(service)))
     }
 
+  // Note: permitted for user with service enrolment
   def enrolmentAlreadyExistsForGroup(service: Service): Action[AnyContent] =
-    authAction.ggAuthorisedUserWithEnrolmentsAction {
+    authAction.ggAuthorisedUserWithServiceAction {
       implicit request => _: LoggedInUserWithEnrolments =>
         Future.successful(Ok(registrationExistsForGroupView(service)))
     }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/HasExistingEoriController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/HasExistingEoriController.scala
@@ -41,15 +41,10 @@ class HasExistingEoriController @Inject() (
     extends CdsController(mcc) with EnrolmentExtractor {
 
   def displayPage(service: Service): Action[AnyContent] = authAction.ggAuthorisedUserWithEnrolmentsAction {
-    implicit request =>
-      implicit loggedInUser: LoggedInUserWithEnrolments =>
-        // Guard against user already being enrolled to service (e.g. by using back-button)
-        if (enrolledForService(loggedInUser, service).isDefined)
-          Future.successful(Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(service)))
-        else
-          existingEoriToUse.map { eori =>
-            Ok(hasExistingEoriView(service, eori))
-        }
+    implicit request => implicit loggedInUser: LoggedInUserWithEnrolments =>
+      existingEoriToUse.map { eori =>
+        Ok(hasExistingEoriView(service, eori))
+      }
   }
 
   def enrol(service: Service): Action[AnyContent] =
@@ -62,7 +57,8 @@ class HasExistingEoriController @Inject() (
       }
     }
 
-  def enrolSuccess(service: Service): Action[AnyContent] = authAction.ggAuthorisedUserWithEnrolmentsAction {
+  // Note: permitted for user with service enrolment
+  def enrolSuccess(service: Service): Action[AnyContent] = authAction.ggAuthorisedUserWithServiceAction {
     implicit request => implicit loggedInUser: LoggedInUserWithEnrolments =>
       existingEoriToUse.map { eori =>
         Ok(enrolSuccessView(eori, service))

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/JourneyTypeFromUrl.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/JourneyTypeFromUrl.scala
@@ -22,7 +22,6 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.Journey
 trait JourneyTypeFromUrl {
 
   def journeyFromUrl(implicit request: Request[AnyContent]): Journey.Value =
-    if (request.path.contains("/subscribe/") || request.path.endsWith("/subscribe")) Journey.Subscribe
-    else Journey.Register
+    Journey.journeyFromRequest
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AuthAction.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AuthAction.scala
@@ -47,7 +47,7 @@ class AuthAction @Inject() (
   private val extendedRetrievals = baseRetrievals and internalId and allEnrolments and groupIdentifier
 
   /**
-    * Returns a GG user with correct user type, affinity group and no enrolment to service
+    * Allows Gov Gateway user with correct user type, affinity group and no enrolment to service
     */
   def ggAuthorisedUserWithEnrolmentsAction(requestProcessor: RequestProcessorSimple) =
     Action.async { implicit request =>
@@ -55,7 +55,7 @@ class AuthAction @Inject() (
     }
 
   /**
-    * Returns a GG user with correct user type and affinity group but no check for enrolment to service
+    * Allows Gov Gateway user with correct user type and affinity group but no check for enrolment to service
     */
   def ggAuthorisedUserWithServiceAction(requestProcessor: RequestProcessorSimple) =
     Action.async { implicit request =>
@@ -63,7 +63,7 @@ class AuthAction @Inject() (
     }
 
   /**
-    * Returns a GG user without checks for user type, affinity group or enrolment to service
+    * Allows Gov Gateway user without checks for user type, affinity group or enrolment to service
     */
   def ggAuthorisedUserAction(requestProcessor: RequestProcessorSimple) =
     Action.async { implicit request =>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AuthAction.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AuthAction.scala
@@ -46,16 +46,25 @@ class AuthAction @Inject() (
   private val baseRetrievals     = ggEmail and credentialRole and affinityGroup
   private val extendedRetrievals = baseRetrievals and internalId and allEnrolments and groupIdentifier
 
+  /**
+    * Returns a GG user with correct user type, affinity group and no enrolment to service
+    */
   def ggAuthorisedUserWithEnrolmentsAction(requestProcessor: RequestProcessorSimple) =
     Action.async { implicit request =>
       authorise(requestProcessor)
     }
 
+  /**
+    * Returns a GG user with correct user type and affinity group but no check for enrolment to service
+    */
   def ggAuthorisedUserWithServiceAction(requestProcessor: RequestProcessorSimple) =
     Action.async { implicit request =>
-      authorise(requestProcessor, checkPermittedAccess = false, checkServiceEnrolment = false)
+      authorise(requestProcessor, checkServiceEnrolment = false)
     }
 
+  /**
+    * Returns a GG user without checks for user type, affinity group or enrolment to service
+    */
   def ggAuthorisedUserAction(requestProcessor: RequestProcessorSimple) =
     Action.async { implicit request =>
       authorise(requestProcessor, checkPermittedAccess = false)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Journey.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Journey.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eoricommoncomponent.frontend.models
 
 import play.api.libs.json.{Reads, Writes}
-import play.api.mvc.{PathBindable, QueryStringBindable}
+import play.api.mvc.{PathBindable, QueryStringBindable, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.util.Constants
 
 object Journey extends Enumeration {
@@ -57,5 +57,14 @@ object Journey extends Enumeration {
 
       override def unbind(key: String, value: Journey.Value): String = pathBindable.unbind(key, value)
     }
+
+  def journeyFromRequest(implicit request: Request[_]): Journey.Value = {
+    val path = request.path
+    if (path.contains("/subscribe/") || path.endsWith("/subscribe"))
+      Journey.Subscribe
+    else
+      Journey.Register
+
+  }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Service.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Service.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eoricommoncomponent.frontend.models
 
-import play.api.mvc.PathBindable
+import play.api.mvc.{PathBindable, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.util.Constants
 
 sealed trait Service {
@@ -46,7 +46,7 @@ object Service {
     override val enrolmentKey: String = ""
   }
 
-  val supportedServices = Set[Service](ATaR)
+  private val supportedServices = Set[Service](ATaR)
 
   def withName(str: String): Option[Service] =
     supportedServices.find(_.code == str)
@@ -60,6 +60,11 @@ object Service {
       } yield service
 
     override def unbind(key: String, value: Service): String = stringBinder.unbind(key, value.code)
+  }
+
+  def serviceFromRequest(implicit request: Request[_]): Option[Service] = {
+    val path = request.path
+    supportedServices.find(service => path.contains(s"/${service.code}/"))
   }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/JourneyExtractor.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/JourneyExtractor.scala
@@ -21,13 +21,6 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.Journey
 
 object JourneyExtractor {
 
-  def journey(implicit request: Request[_]): Journey.Value = {
-    val path = request.path
-    if (path.contains("/subscribe/") || path.endsWith("/subscribe"))
-      Journey.Subscribe
-    else
-      Journey.Register
-
-  }
+  def journey(implicit request: Request[_]): Journey.Value = Journey.journeyFromRequest
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/ServiceName.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/ServiceName.scala
@@ -41,9 +41,7 @@ object ServiceName {
   def shortName(implicit messages: Messages, request: Request[_]): String =
     shortName(service)
 
-  def service(implicit request: Request[_]): Service = {
-    val path = request.path
-    Service.supportedServices.find(service => path.contains(s"/${service.code}/")).getOrElse(Service.NullService)
-  }
+  def service(implicit request: Request[_]): Service =
+    Service.serviceFromRequest.getOrElse(Service.NullService)
 
 }

--- a/test/unit/allowlist/AllowlistVerificationSpec.scala
+++ b/test/unit/allowlist/AllowlistVerificationSpec.scala
@@ -63,28 +63,6 @@ class AllowlistVerificationSpec extends ControllerSpec with BeforeAndAfterEach w
 
   "Allowlist verification" should {
 
-    "redirect to unauthorised page when a non-allowlisted user attempts to access a route" in {
-      AuthBuilder.withAuthorisedUser("user-1236213", mockAuthConnector, userEmail = Some("not@example.com"))
-
-      val result = controller
-        .download()
-        .apply(SessionBuilder.buildRequestWithSessionAndPath("/customs-enrolment-services/subscribe/", defaultUserId))
-
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe Some("/customs-enrolment-services/subscribe/unauthorised")
-    }
-
-    "redirect to unauthorised page when a user with no email address attempts to access a route" in {
-      AuthBuilder.withAuthorisedUser("user-1236213", mockAuthConnector, userEmail = None)
-
-      val result = controller
-        .download()
-        .apply(SessionBuilder.buildRequestWithSessionAndPath("/customs-enrolment-services/subscribe/", defaultUserId))
-
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe Some("/customs-enrolment-services/subscribe/unauthorised")
-    }
-
     "return OK (200) when a allowlisted user attempts to access a route" in {
       AuthBuilder.withAuthorisedUser("user-2300121", mockAuthConnector, userEmail = Some("mister_allow@example.com"))
 

--- a/test/unit/allowlist/AllowlistVerificationWithEnrolmentsSpec.scala
+++ b/test/unit/allowlist/AllowlistVerificationWithEnrolmentsSpec.scala
@@ -54,28 +54,6 @@ class AllowlistVerificationWithEnrolmentsSpec extends ControllerSpec with Before
 
   "Allowlist verification" should {
 
-    "return Unauthorized (401) when a non-allowlisted user attempts to access a route" in {
-      AuthBuilder.withAuthorisedUser(defaultUserId, mockAuthConnector, userEmail = Some("not@example.com"))
-
-      val result = controller
-        .form(Journey.Subscribe)
-        .apply(SessionBuilder.buildRequestWithSessionAndPath("/customs-enrolment-services/subscribe/", defaultUserId))
-
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe Some("/customs-enrolment-services/subscribe/unauthorised")
-    }
-
-    "return Unauthorized (401) when a user attempts to access a route and they do not have an email address" in {
-      AuthBuilder.withAuthorisedUser(defaultUserId, mockAuthConnector, userEmail = None)
-
-      val result = controller
-        .form(Journey.Subscribe)
-        .apply(SessionBuilder.buildRequestWithSessionAndPath("/customs-enrolment-services/subscribe/", defaultUserId))
-
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe Some("/customs-enrolment-services/subscribe/unauthorised")
-    }
-
     "return OK (200) when a allowlisted user attempts to access a route" in {
       AuthBuilder.withAuthorisedUser(defaultUserId, mockAuthConnector, userEmail = Some("mister_allow@example.com"))
 

--- a/test/unit/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/controllers/ApplicationControllerSpec.scala
@@ -61,6 +61,9 @@ class ApplicationControllerSpec extends ControllerSpec with BeforeAndAfterEach w
   override def beforeEach: Unit = {
     super.beforeEach()
     reset(mockAuthConnector, enrolmentStoreProxyService, mockSessionCache)
+
+    when(enrolmentStoreProxyService.enrolmentForGroup(any(), any())(any()))
+      .thenReturn(Future.successful(None))
   }
 
   private def groupEnrolment(service: Service) = Some(
@@ -78,9 +81,6 @@ class ApplicationControllerSpec extends ControllerSpec with BeforeAndAfterEach w
     }
 
     "direct authenticated users to start subscription" in {
-      when(enrolmentStoreProxyService.enrolmentForGroup(any(), any())(any()))
-        .thenReturn(Future.successful(None))
-
       withAuthorisedUser(defaultUserId, mockAuthConnector)
       val result =
         controller.startSubscription(Service.ATaR).apply(SessionBuilder.buildRequestWithSession(defaultUserId))
@@ -127,7 +127,9 @@ class ApplicationControllerSpec extends ControllerSpec with BeforeAndAfterEach w
       withAuthorisedUser(defaultUserId, mockAuthConnector, otherEnrolments = Set(atarEnrolment))
 
       val result =
-        controller.startSubscription(Service.ATaR).apply(SessionBuilder.buildRequestWithSession(defaultUserId))
+        controller.startSubscription(Service.ATaR).apply(
+          SessionBuilder.buildRequestWithSessionAndPath("/atar/subscribe", defaultUserId)
+        )
 
       status(result) shouldBe SEE_OTHER
       await(result).header.headers("Location") should endWith("enrolment-already-exists")

--- a/test/unit/controllers/HasExistingEoriControllerSpec.scala
+++ b/test/unit/controllers/HasExistingEoriControllerSpec.scala
@@ -152,7 +152,13 @@ class HasExistingEoriControllerSpec extends ControllerSpec with BeforeAndAfterEa
       cdsEnrolmentId = cdsEnrolmentId,
       otherEnrolments = otherEnrolments
     )
-    await(test(controller.displayPage(service).apply(SessionBuilder.buildRequestWithSession(defaultUserId))))
+    await(
+      test(
+        controller.displayPage(service).apply(
+          SessionBuilder.buildRequestWithSessionAndPath("/atar/subscribe/", defaultUserId)
+        )
+      )
+    )
   }
 
   private def enrol(service: Service, responseStatus: Int)(test: Future[Result] => Any) = {

--- a/test/util/builders/SessionBuilder.scala
+++ b/test/util/builders/SessionBuilder.scala
@@ -66,7 +66,7 @@ object SessionBuilder {
   }
 
   def buildRequestWithSessionAndPath(path: String, authToken: String, method: String = "GET") =
-    FakeRequest(method, path).withSession(sessionMap(authToken): _*)
+    addToken(FakeRequest(method, path)).withSession(sessionMap(authToken): _*)
 
   def buildRequestWithSessionAndPathAndFormValues(
     method: String,


### PR DESCRIPTION
This is done by moving the check for existing enrolment for service to AuthAction - i.e. every page will be protected with this check.

We therefore need to _allow_ access with (e.g. ATaR) enrolment to confirmation and you are enrolled page.