### PR TITLE
ECC-165 - handle 093 error response

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/SubscriptionService.scala
@@ -127,7 +127,12 @@ class SubscriptionService @Inject() (connector: SubscriptionServiceConnector, fe
         case MessagingServiceParam.Fail if responseCommon.statusText.contains(SubscriptionInProgress) =>
           SubscriptionFailed(SubscriptionInProgress, processingDate)
         case MessagingServiceParam.Fail =>
-          SubscriptionFailed("Response status of FAIL returned for a SUB02: Create Subscription.", processingDate)
+          val message =
+            s"Response status of FAIL returned for a SUB02: Create Subscription.${responseCommon.statusText.map(
+              text => s" $text"
+            ).getOrElse("")}"
+          CdsLogger.error(message)
+          SubscriptionFailed(message, processingDate)
       }
     }
 

--- a/test/unit/services/subscription/SubscriptionServiceSpec.scala
+++ b/test/unit/services/subscription/SubscriptionServiceSpec.scala
@@ -334,13 +334,18 @@ class SubscriptionServiceSpec
     }
 
     "return a valid fail response when subscription fails for business reason" in {
+      val errorFromEIS = "999 - Some error occurred"
+
       val expectedFailure =
-        SubscriptionFailed("Response status of FAIL returned for a SUB02: Create Subscription.", "18 Aug 2016")
+        SubscriptionFailed(
+          "Response status of FAIL returned for a SUB02: Create Subscription. " + errorFromEIS,
+          "18 Aug 2016"
+        )
 
       val service = constructService(
         connectorMock =>
           when(connectorMock.subscribe(ArgumentMatchers.any())(ArgumentMatchers.any()))
-            .thenReturn(Future.successful(subscriptionFailedResponseJson()).as[SubscriptionResponse])
+            .thenReturn(Future.successful(subscriptionFailedResponseJson(errorFromEIS)).as[SubscriptionResponse])
       )
 
       val res = await(


### PR DESCRIPTION
These are the minimum changes I believe we need to make.  The "093" is just another error that we don't need to specifically handle.  This change just adds the returned 'statusText' to our generic message and logs it at ERROR level.