### PR TITLE
ECC-159 - un-block 'register' route and default to 'cds' 

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/subscription/VatGroupController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/subscription/VatGroupController.scala
@@ -39,7 +39,7 @@ class VatGroupController @Inject() (mcc: MessagesControllerComponents, vatGroupV
         formWithErrors => BadRequest(vatGroupView(formWithErrors, journey)),
         yesNoAnswer =>
           if (yesNoAnswer.isNo)
-            Redirect(EmailController.form(Service.NullService, Journey.Register))
+            Redirect(EmailController.form(Service.CDS, Journey.Register))
           else
             Redirect(routes.VatGroupsCannotRegisterUsingThisServiceController.form(journey))
       )

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Service.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Service.scala
@@ -46,7 +46,7 @@ object Service {
     override val enrolmentKey: String = ""
   }
 
-  private val supportedServices = Set[Service](ATaR)
+  private val supportedServices = Set[Service](ATaR, CDS)
 
   def withName(str: String): Option[Service] =
     supportedServices.find(_.code == str)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -148,7 +148,7 @@ allowlistEnabled = false
 allowlist = ""
 allowlist-referrers = ""
 # comma separated list of uri to block
-routes-to-block = "register"
+routes-to-block = "cds/subscribe"
 
 features {
   matchingEnabled = true

--- a/test/unit/config/AppConfigSpec.scala
+++ b/test/unit/config/AppConfigSpec.scala
@@ -29,7 +29,7 @@ class AppConfigSpec extends ControllerSpec {
 
     "have blockedRoutesRegex defined" in {
       appConfig.blockedRoutesRegex.size shouldBe 1
-      appConfig.blockedRoutesRegex.head.pattern.pattern() shouldBe "register"
+      appConfig.blockedRoutesRegex.head.pattern.pattern() shouldBe "cds/subscribe"
     }
 
     "have ttl defined" in {


### PR DESCRIPTION
This PR provides the minimum changes to get the register journey "working" - i.e. re-enabled so that, locally, a user can progress through to the "CYA" page and submit a request.

The "service" enrolment for register journey defaults to CDS - so CDS has been added to the list of supported services.

However, we don't want to support "CDS" as part of the subscribe journey - so the "cds/subscribe" url has been added to the block list.