### PR TITLE
BAU - tidy up integration tests - stop logs re un-matched wiremock calls

### DIFF
--- a/test/integration/HandleSubscriptionConnectorSpec.scala
+++ b/test/integration/HandleSubscriptionConnectorSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.connector.HandleSubscriptionConn
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.HandleSubscriptionRequest
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier}
 import util.externalservices.ExternalServicesConfig.{Host, Port}
-import util.externalservices.HandleSubscriptionService
+import util.externalservices.{AuditService, HandleSubscriptionService}
 
 class HandleSubscriptionConnectorSpec extends IntegrationTestsSpec with ScalaFutures {
 
@@ -82,6 +82,7 @@ class HandleSubscriptionConnectorSpec extends IntegrationTestsSpec with ScalaFut
 
   before {
     resetMockServer()
+    AuditService.stubAuditService()
   }
 
   override def beforeAll: Unit =

--- a/test/integration/Save4LaterConnectorSpec.scala
+++ b/test/integration/Save4LaterConnectorSpec.scala
@@ -44,6 +44,7 @@ class Save4LaterConnectorSpec extends IntegrationTestsSpec with ScalaFutures {
 
   before {
     resetMockServer()
+    AuditService.stubAuditService()
   }
 
   override def beforeAll: Unit =
@@ -97,7 +98,7 @@ class Save4LaterConnectorSpec extends IntegrationTestsSpec with ScalaFutures {
     "return  BadRequestException with response status NOT FOUND status for unknown entry" in {
       stubSave4LaterNotFoundDELETE()
       intercept[BadRequestException] {
-        await(save4LaterConnector.delete[String]("id"))
+        await(save4LaterConnector.delete[String](id))
       }
     }
   }

--- a/test/util/externalservices/AuditService.scala
+++ b/test/util/externalservices/AuditService.scala
@@ -23,7 +23,7 @@ object AuditService {
 
   private val AuditWriteUrl: String = "/write/audit"
 
-  def stubAuditService(): Unit =
+  def stubAuditService(): Unit = {
     stubFor(
       post(urlEqualTo(AuditWriteUrl))
         .willReturn(
@@ -31,6 +31,14 @@ object AuditService {
             .withStatus(Status.OK)
         )
     )
+    stubFor(
+      post(urlEqualTo(AuditWriteUrl + "/merged"))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+        )
+    )
+  }
 
   def verifyXAuditWrite(times: Int): Unit = verify(times, postRequestedFor(urlEqualTo(AuditWriteUrl)))
 }


### PR DESCRIPTION
Following another random Jenkins build failure I've taken a look at the "un-matched" wiremock calls when running our ITs.
Don't know if this will fix the problem but it should remove some of the clutter.