### PR TITLE
ECC-327 - stop using native html validation

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/address.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/address.scala.html
@@ -84,7 +84,7 @@ isRow: Boolean = false)(implicit request: Request[_], messages: Messages)
 
     @helpers.errorSummary(addressForm)
 
-    @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.AddressController.submit(isInReviewMode, service, journey), 'id -> "addressDetailsForm") {
+    @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.AddressController.submit(isInReviewMode, service, journey), "addressDetailsForm") {
 
         @CSRF.formField
         <fieldset>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email/check_your_email.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email/check_your_email.scala.html
@@ -52,7 +52,7 @@
     @helpers.errorSummary(confirmEmailYesNoAnswerForm, focusOverrides = Map("yes-no-answer" -> "yes-no-answer-true"))
 
 
-    @helper.form(CheckYourEmailController.submit(service, journey), 'id -> "confirmEmailYesNoAnswerForm") {
+    @helpers.form(CheckYourEmailController.submit(service, journey), "confirmEmailYesNoAnswerForm") {
     @CSRF.formField
 
     @inputRadioGroup("yes-no-answer",

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email/verify_your_email.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email/verify_your_email.scala.html
@@ -31,7 +31,7 @@ journey: Journey.Value)(implicit request: Request[_], messages: Messages)
     <a href="javascript:history.back()" id="back" class="link-back js-visible">@messages("cds.navigation.back")</a>
 
 
-    @helper.form(CheckYourEmailController.submit(service, journey)) {
+    @helpers.form(CheckYourEmailController.submit(service, journey)) {
 
         @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email/what_is_your_email.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email/what_is_your_email.scala.html
@@ -44,7 +44,7 @@
 
     @helpers.errorSummary(emailForm)
 
-    @helper.form(WhatIsYourEmailController.submit(service, journey),'id -> "emailForm") {
+    @helpers.form(WhatIsYourEmailController.submit(service, journey),"emailForm") {
 
         @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/has_existing_eori.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/has_existing_eori.scala.html
@@ -33,7 +33,7 @@
     <p id="para2">@messages("cds.has-existing-eori.para2")</p>
     <p id="para3">@messages("cds.has-existing-eori.para3")</p>
 
-    @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.HasExistingEoriController.enrol(service)) {
+    @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.HasExistingEoriController.enrol(service)) {
         @CSRF.formField
 
         <p><input class="button" type="submit" value='@uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.subscription.ViewHelper.continueButtonText(false)'></p>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/form.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/form.scala.html
@@ -1,0 +1,19 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(action: play.api.mvc.Call, id: String = "form")(body: => Html)
+
+@helper.form(action,'id -> id, 'novalidate -> "")(body)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/check_your_details.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/check_your_details.scala.html
@@ -285,7 +285,7 @@
             <p class="govuk-body">@messages("cds.form.disclaimer")</p>
 
             <div class="form-group">
-                @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.RegisterWithEoriAndIdController.registerWithEoriAndId(service, journey)) {
+                @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.RegisterWithEoriAndIdController.registerWithEoriAndId(service, journey)) {
                     @CSRF.formField
 
                     <p><input class="button" type="submit" value="@messages("cds.form.send")"></p>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/enter_your_details.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/enter_your_details.scala.html
@@ -58,7 +58,7 @@
 
         <h1 class="heading-large">@messages("cds.matching.individual.header")</h1>
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.migration.routes.NameDobSoleTraderController.submit(isInReviewMode, service, journey), 'id -> "subscriptionNameDobForm") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.migration.routes.NameDobSoleTraderController.submit(isInReviewMode, service, journey), "subscriptionNameDobForm") {
         @CSRF.formField
 
             @inputText("first-name", firstNameLabel, '_autocomplete ->  "given-name")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/how_can_we_identify_you.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/how_can_we_identify_you.scala.html
@@ -44,11 +44,11 @@
                 <h1 class="heading-large">@messages("subscription-journey.how-confirm-identity")</h1>
             </legend>
 
-            @helper.form(
+            @helpers.form(
             if(journey == Journey.Subscribe)
                 HowCanWeIdentifyYouController.submit(isInReviewMode, service, journey)
             else
-                GYEHowCanWeIdentifyYouController.submit(organisationType.getOrElse(throw new IllegalArgumentException("Missing Organisation type")), service, journey), 'id -> "nino-utr-form") {
+                GYEHowCanWeIdentifyYouController.submit(organisationType.getOrElse(throw new IllegalArgumentException("Missing Organisation type")), service, journey), "nino-utr-form") {
             @CSRF.formField
             <div class="form-group @if(elements.hasErrors){error}">
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/match_nino_subscription.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/match_nino_subscription.scala.html
@@ -41,7 +41,7 @@
 
     @helpers.errorSummary(matchNinoIdForm)
 
-    @helper.form(HaveNinoSubscriptionController.submit(service, journey), 'id -> "subscriptionNinoForm") {
+    @helpers.form(HaveNinoSubscriptionController.submit(service, journey), "subscriptionNinoForm") {
     @CSRF.formField
     <div class="form-group">
         @helpers.hideRevealToggle(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/match_utr_subscription.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/match_utr_subscription.scala.html
@@ -78,7 +78,7 @@
 
     @helpers.errorSummary(matchOrgIdForm)
 
-    @helper.form(HaveUtrSubscriptionController.submit(service, journey), 'id -> "subscriptionUtrForm") {
+    @helpers.form(HaveUtrSubscriptionController.submit(service, journey), "subscriptionUtrForm") {
     @CSRF.formField
     <div class="form-group">
         @helpers.hideRevealToggle(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/nameId.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/nameId.scala.html
@@ -59,7 +59,7 @@
 
     <h1 class="heading-large">@headerAndTitle</h1>
 
-    @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.migration.routes.NameIDOrgController.submit(isInReviewMode, service, journey), 'id -> "nameUtrOrganisationForm") {
+    @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.migration.routes.NameIDOrgController.submit(isInReviewMode, service, journey), "nameUtrOrganisationForm") {
         @CSRF.formField
 
         @inputText(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/nameOrg.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/nameOrg.scala.html
@@ -40,7 +40,7 @@
     @helpers.errorSummary(nameOrganisationForm)
 
     <div class="form-group">
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.migration.routes.NameOrgController.submit(isInReviewMode, service, journey), 'id -> "nameUtrOrganisationForm") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.migration.routes.NameOrgController.submit(isInReviewMode, service, journey), "nameUtrOrganisationForm") {
 
         @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/use_this_eori.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/use_this_eori.scala.html
@@ -34,7 +34,7 @@ service: Service)(implicit request: Request[_], messages: Messages)
     <div class="column-two-thirds">
         <a href="javascript:history.back()" id="back" class="link-back js-visible">@messages("cds.navigation.back")</a>
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.UseThisEoriController.submit(service), 'id -> "eoriNumberForm") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.UseThisEoriController.submit(service), "eoriNumberForm") {
             @CSRF.formField
 
             <h1 class="heading-large">@messages("cds.subscribe.use-this-eori.heading")</h1>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/what_is_your_eori.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/what_is_your_eori.scala.html
@@ -50,7 +50,7 @@
 
     @helpers.errorSummary(eoriNumberForm)
 
-    @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.WhatIsYourEoriController.submit(isInReviewMode, service),'id -> "eoriNumberForm") {
+    @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.WhatIsYourEoriController.submit(isInReviewMode, service), "eoriNumberForm") {
         @CSRF.formField
 
         @inputText("eori-number",

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/check_your_details_register.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/check_your_details_register.scala.html
@@ -359,7 +359,7 @@ isUserIdentifiedByRegService: Boolean
         <p id="disclaimer-content">@messages("cds.form.disclaimer")</p>
 
         <div class="form-group">
-            @helper.form(CheckYourDetailsRegisterController.submitDetails(service, journey)) {
+            @helpers.form(CheckYourDetailsRegisterController.submitDetails(service, journey)) {
                 @CSRF.formField
 
                 <p><input class="button" type="submit" value=@messages("cds.form.send")></p>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/confirm_contact_details.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/confirm_contact_details.scala.html
@@ -176,7 +176,7 @@ journey: Journey.Value)(implicit request: Request[_], messages: Messages)
     </dl>
 
     <div class="form-group">
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.ConfirmContactDetailsController.submit(service, journey), 'id -> "yes-no-wrong-address-form") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.ConfirmContactDetailsController.submit(service, journey), "yes-no-wrong-address-form") {
             @CSRF.formField
 
             @inputRadioGroup("yes-no-wrong-address",

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/isle_of_man.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/isle_of_man.scala.html
@@ -44,7 +44,7 @@
 
     @helpers.errorSummary(isleOfManYesNoAnswerForm, focusOverrides = Map("yes-no-answer" -> "yes-no-answer-true"))
 
-    @helper.form(formAction, 'id -> "yes-no-form") {
+    @helpers.form(formAction, "yes-no-form") {
 
     @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_name_id_organisation.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_name_id_organisation.scala.html
@@ -56,7 +56,7 @@
         <h1 class="heading-large">@headerAndTitle</h1>
 
         <div class="form-group">
-            @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.NameIdOrganisationController.submit(organisationType, service, journey), 'id -> "matchNameUtrOrganisationForm") {
+            @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.NameIdOrganisationController.submit(organisationType, service, journey), "matchNameUtrOrganisationForm") {
             @CSRF.formField
 
                 @inputText(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_namedob.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_namedob.scala.html
@@ -46,7 +46,7 @@
 
         <h1 class="heading-large">@messages("cds.matching.individual.header")</h1>
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.NameDobController.submit(organisationType, service, journey), 'id -> "matchIndividualForm") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.NameDobController.submit(organisationType, service, journey), "matchIndividualForm") {
         @CSRF.formField
             @inputText("first-name", messages("cds.matching.individual.first-name"), '_autocomplete ->  "given-name")
             @inputText("last-name", messages("cds.matching.individual.last-name"), '_autocomplete ->  "family-name")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_nino.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_nino.scala.html
@@ -41,7 +41,7 @@
 
     <h1>@messages("cds.matching.nino.header")</h1>
 
-    @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.NinoController.submit(organisationType, service, journey), 'id -> "nino-form") {
+    @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.NinoController.submit(organisationType, service, journey), "nino-form") {
     @CSRF.formField
     @inputText("first-name", messages("cds.matching.nino.first-name"))
     @inputText("last-name", messages("cds.matching.nino.last-name"))

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_nino_row_individual.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_nino_row_individual.scala.html
@@ -39,7 +39,7 @@
 
     @helpers.errorSummary(matchNinoIdForm)
 
-    @helper.form(DoYouHaveNinoController.submit(service, journey), 'id -> "matchRowIndividualsNinoForm") {
+    @helpers.form(DoYouHaveNinoController.submit(service, journey), "matchRowIndividualsNinoForm") {
     @CSRF.formField
     <div class="form-group">
         @helpers.hideRevealToggle(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_organisation_utr.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/match_organisation_utr.scala.html
@@ -78,7 +78,7 @@
 
         @helpers.errorSummary(matchOrgIdForm)
 
-            @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.DoYouHaveAUtrNumberController.submit(organisationType, service, journey, isInReviewMode), 'id -> "matchOrganisationUtrForm") {
+            @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.DoYouHaveAUtrNumberController.submit(organisationType, service, journey, isInReviewMode), "matchOrganisationUtrForm") {
             @CSRF.formField
             <div class="form-group">
                 @helpers.hideRevealToggle(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/organisation_type.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/organisation_type.scala.html
@@ -87,7 +87,7 @@
 
         @helpers.errorSummary(OrganisationTypeForm, focusOverrides = Map("organisation-type" -> s"organisation-type-${validOptions.head._1}"))
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.OrganisationTypeController.submit(service, journey), 'id -> "OrganisationTypeForm") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.OrganisationTypeController.submit(service, journey), "OrganisationTypeForm") {
             @CSRF.formField
 
             @inputRadioGroup("organisation-type", validOptions, hintTextOptions)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/row_individual_name_dob.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/row_individual_name_dob.scala.html
@@ -45,7 +45,7 @@
 
         <h1 class="heading-large">@messages("cds.matching.individual.header")</h1>
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.RowIndividualNameDateOfBirthController.submit(isInReviewMode, organisationType, service, journey), 'id -> s"$organisationType-form") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.RowIndividualNameDateOfBirthController.submit(isInReviewMode, organisationType, service, journey), s"$organisationType-form") {
         @CSRF.formField
             @inputText("given-name", messages("cds.matching.individual.given-name"), '_autocomplete ->  "given-name")
             @inputText("middle-name", messages("cds.matching.individual.middle-name.optional"), '_autocomplete ->  "additional-name")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/six_line_address.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/six_line_address.scala.html
@@ -59,7 +59,7 @@
 
         <h1 class="heading-large">@messages(headerLabel)</h1>
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.SixLineAddressController.submit(isInReviewMode, cdsOrgType, service, journey), 'id -> s"$cdsOrgType-form") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.SixLineAddressController.submit(isInReviewMode, cdsOrgType, service, journey), s"$cdsOrgType-form") {
         @CSRF.formField
 
             @inputTextBoundToForm("line-1", messages("cds.matching.organisation-address.line-1"), '_autocomplete ->  "address-line1")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/user_location.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/user_location.scala.html
@@ -66,7 +66,7 @@
 
         @helpers.errorSummary(userLocationForm, focusOverrides = Map("location" -> s"location-${validOptions.head._1}"))
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.UserLocationController.submit(service, journey), 'id -> "user-location-form") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.UserLocationController.submit(service, journey), "user-location-form") {
             @CSRF.formField
 
             @inputRadioGroup("location", validOptions)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/vat_registered_uk.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/vat_registered_uk.scala.html
@@ -45,7 +45,7 @@ uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.VatRegi
 
     @helpers.errorSummary(vatRegisteredUkYesNoAnswerForm, focusOverrides = Map("yes-no-answer" -> "yes-no-answer-true"))
 
-    @helper.form(formAction, 'id -> "yes-no-form") {
+    @helpers.form(formAction, "yes-no-form") {
 
     @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/what_is_your_org_name.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/registration/what_is_your_org_name.scala.html
@@ -36,7 +36,7 @@
         @helpers.errorSummary(matchOrgNameForm)
 
         <div class="form-group">
-            @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.WhatIsYourOrgNameController.submit(isInReviewMode, organisationType, service, journey), 'id -> "matchOrganisationNameForm") {
+            @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.WhatIsYourOrgNameController.submit(isInReviewMode, organisationType, service, journey), "matchOrganisationNameForm") {
             @CSRF.formField
 
                 @inputText(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/are_you_sure_remove_vat.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/are_you_sure_remove_vat.scala.html
@@ -57,8 +57,7 @@
     <fieldset>
         <legend>
             <h1 class="heading-large" id="titleHeading">@heading</h1>
-            @helper.form(AreYouSureYouWantToDeleteVatController.submit(vatDetail.index, service, journey, isInReviewMode),
-            'id -> "vatDetailEuRemoveCreateForm") {
+            @helpers.form(AreYouSureYouWantToDeleteVatController.submit(vatDetail.index, service, journey, isInReviewMode), "vatDetailEuRemoveCreateForm") {
 
             @CSRF.formField
         </legend>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/business_short_name.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/business_short_name.scala.html
@@ -43,7 +43,7 @@
     
         @helpers.errorSummary(shortNameForm)
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.BusinessShortNameController.submit(isInReviewMode, service, journey), 'id -> "shortNameForm") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.BusinessShortNameController.submit(isInReviewMode, service, journey), "shortNameForm") {
 
             @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/confirm_individual_type.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/confirm_individual_type.scala.html
@@ -45,7 +45,7 @@
 
         @helpers.errorSummary(confirmationForm, focusOverrides = Map("individual-type" -> s"individual-type-${validOptions.head._1}"))
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.ConfirmIndividualTypeController.submit(service, journey), 'id -> "confirm-individual-type-form") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.ConfirmIndividualTypeController.submit(service, journey), "confirm-individual-type-form") {
             @CSRF.formField
         
             @inputRadioGroup("individual-type", validOptions)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/contact_details.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/contact_details.scala.html
@@ -76,7 +76,7 @@
 
     @helpers.errorSummary(contactForm)
 
-    @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.ContactDetailsController.submit(isInReviewMode, service, journey), 'id -> "contactDetailsForm") {
+    @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.ContactDetailsController.submit(isInReviewMode, service, journey), "contactDetailsForm") {
 
         @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/date_of_establishment.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/date_of_establishment.scala.html
@@ -56,7 +56,7 @@
         @helpers.errorSummary(updateFormErrors,
             focusOverrides = Map("date-of-establishment" -> "date-of-establishment.day"))
 
-        @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.DateOfEstablishmentController.submit(isInReviewMode, service, journey), 'id -> "date-of-birth-form") {
+        @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.DateOfEstablishmentController.submit(isInReviewMode, service, journey), "date-of-birth-form") {
 
         @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/disclose_personal_details_consent.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/disclose_personal_details_consent.scala.html
@@ -76,7 +76,7 @@ journey: Journey.Value)(implicit request: Request[_], messages: Messages)
 
         @helpers.errorSummary(disclosePersonalDetailsYesNoAnswerForm, focusOverrides = Map("yes-no-answer" -> "yes-no-answer-true"))
 
-        @helper.form(formAction, 'id -> "disclose-personal-details-createForm") {
+        @helpers.form(formAction, "disclose-personal-details-createForm") {
 
             @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/existing_match_subscribe_rcm.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/existing_match_subscribe_rcm.scala.html
@@ -137,7 +137,7 @@
         <p>@messages("cds.form.disclaimer")</p>
 
         <div class="form-group">
-            @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.CheckYourDetailsRegisterController.submitDetails(service, journey)) {
+            @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes.CheckYourDetailsRegisterController.submitDetails(service, journey)) {
                 @CSRF.formField
 
                 <p><input class="button" type="submit" value="@messages("cds.form.register")"></p>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sic_code.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sic_code.scala.html
@@ -82,7 +82,7 @@ cdsOrgType.contains(CdsOrganisationType.ThirdCountryOrganisation)
 
 @subscriptionFlowCommon_di(pageKey = pageKeyForOrgType, form = sicCodeForm) {
 
-    @helper.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.SicCodeController.submit(isInReviewMode, service, journey),'id -> "sicCodeform") {
+    @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.SicCodeController.submit(isInReviewMode, service, journey), "sicCodeform") {
 
         @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_details.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_details.scala.html
@@ -41,7 +41,7 @@
         @helpers.errorSummary(updateFormErrors,
             focusOverrides = Map("vat-effective-date" -> "vat-effective-date.day"))
 
-        @helper.form(formAction, 'id -> "vat-details-form") {
+        @helpers.form(formAction, "vat-details-form") {
 
             @CSRF.formField
             <h1 class="heading-large">@messages("cds.subscription.vat-details.heading")</h1>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_details_eu.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_details_eu.scala.html
@@ -57,8 +57,7 @@
 
         <h1 class="heading-large">@messages("cds.subscription.vat-enter-eu")</h1>
 
-        @helper.form(submit,
-        'id -> "subscriptionAmendVatEUDetailsForm") {
+        @helpers.form(submit, "subscriptionAmendVatEUDetailsForm") {
 
             @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_details_eu_confirm.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_details_eu_confirm.scala.html
@@ -64,8 +64,7 @@
         <fieldset>
             <legend>
                 <h1 class="heading-large" id="titleHeading">@heading</h1>
-                @helper.form(VatDetailsEuConfirmController.submit(isInReviewMode, service, journey),
-                'id -> "subscriptionVatEUDetailsConfirmForm") {
+                @helpers.form(VatDetailsEuConfirmController.submit(isInReviewMode, service, journey), "subscriptionVatEUDetailsConfirmForm") {
 
                 @CSRF.formField
             </legend>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_group.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_group.scala.html
@@ -45,7 +45,7 @@
 
         @helpers.errorSummary(vatGroupYesNoAnswerForm, focusOverrides = Map("yes-no-answer" -> "yes-no-answer-true"))
 
-        @helper.form(formAction, 'id -> "vat-group-createForm") {
+        @helpers.form(formAction, "vat-group-createForm") {
 
             @CSRF.formField
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_registered_eu.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_registered_eu.scala.html
@@ -57,7 +57,7 @@ journey: Journey.Value)(implicit request: Request[_], messages: Messages)
 
         @helpers.errorSummary(vatRegisteredEuYesNoAnswerForm, focusOverrides = Map("yes-no-answer" -> "yes-no-answer-true"))
 
-        @helper.form(formAction, 'id -> "vat-registered-eu-createForm") {
+        @helpers.form(formAction, "vat-registered-eu-createForm") {
 
         @CSRF.formField
             @inputRadioGroup("yes-no-answer",

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_registered_uk.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/vat_registered_uk.scala.html
@@ -57,7 +57,7 @@ journey: Journey.Value)(implicit request: Request[_], messages: Messages)
 
         @helpers.errorSummary(vatRegisteredUkYesNoAnswerForm, focusOverrides = Map("yes-no-answer" -> "yes-no-answer-true"))
 
-        @helper.form(formAction, 'id -> "vat-registered-uk-createForm") {
+        @helpers.form(formAction, "vat-registered-uk-createForm") {
         @CSRF.formField
 
         @inputRadioGroup("yes-no-answer",


### PR DESCRIPTION
The key to this fix is to add 'novalidate' to the <form> element.  This is done with the use of the new helpers.form component