### PR TITLE
ECC-368 - fix for translating dates on confirmation screens

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/DateFormatter.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/DateFormatter.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers
+
+import javax.inject.Inject
+import org.joda.time.LocalDate
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
+import play.api.i18n.Messages
+import uk.gov.hmrc.play.language.LanguageUtils
+
+class DateFormatter @Inject() (languageUtils: LanguageUtils) {
+
+  val dateFormatter: DateTimeFormatter = DateTimeFormat.forPattern("dd MMM yyyy")
+
+  def format(dateString: String)(implicit messages: Messages): String = {
+
+    def tryConvert =
+      try Some(languageUtils.Dates.formatDate(LocalDate.parse(dateString, dateFormatter)))
+      catch {
+        case e: Exception => None
+      }
+
+    tryConvert.getOrElse(dateString)
+  }
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/migration_success.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/migration_success.scala.html
@@ -18,9 +18,10 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.longName
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback)
+@this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
 @(eori: Option[String], name: String, processedDate: String, service: Service)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("cds.mig.existing.outcomes.application-received.title")) {
@@ -30,7 +31,7 @@
                 @messages("cds.reg.existing.outcomes.success.heading.part1") @name
             </h1>
             <p class="heading-large" id="active-from">
-                @messages("subscription.subscription-results.active-from") @processedDate
+                @messages("subscription.subscription-results.active-from") @dateFormatter.format(processedDate)
             </p>
             <p class="heading-medium mb-0">@messages("cds.reg.existing.outcomes.success.eori.number")</p>
             <p id="eori-number" class="heading-medium mt-0">@eori</p>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub01_outcome_processing.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub01_outcome_processing.scala.html
@@ -18,9 +18,10 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.JourneyExtractor._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback)
+@this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
 @(orgName: Option[String], processedDate: String)(implicit messages: Messages, request: Request[_])
 
 @serviceOrEori = @{
@@ -41,7 +42,7 @@
     <div class="column-two-thirds">
         <div class="govuk-box-highlight">
             <h1 id="page-heading" class="heading-xlarge">@heading</h1>
-            <div class="heading-medium" id="processed-date">@messages("cds.subscription.outcomes.in-processing.received", processedDate)</div>
+            <div class="heading-medium" id="processed-date">@messages("cds.subscription.outcomes.in-processing.received", dateFormatter.format(processedDate))</div>
         </div>
 
         <div id="what-happens-next">

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub01_outcome_rejected.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub01_outcome_rejected.scala.html
@@ -20,9 +20,10 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.JourneyExtractor
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Journey
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help)
+@this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
 @(name: Option[String], processedDate: String, service: Service)(implicit messages: Messages, request: Request[_])
 
 
@@ -41,7 +42,7 @@
         <div class="govuk-box-highlight">
             <h1 id="page-heading" class="heading-xlarge">@heading</h1>
             <div class="heading-medium" id="processed-date">
-                @messages("cds.subscription.outcomes.in-processing.received", processedDate)
+                @messages("cds.subscription.outcomes.in-processing.received", dateFormatter.format(processedDate))
             </div>
         </div>
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub02_eori_already_associated.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub02_eori_already_associated.scala.html
@@ -15,16 +15,17 @@
  *@
 
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback)
+@this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
 @(name: String, processedDate: String)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("cds.sub02.outcome.eori-already-associated.title")) {
     <div class="column-two-thirds">
         <div class="govuk-box-highlight">
             <h1 id="page-heading" class="heading-xlarge" >@messages("cds.sub02.outcome.eori-already-associated.heading", name)</h1>
-            <p class="heading-medium" id="processed-date">@messages("cds.sub02.outcome.eori-already-associated.received", processedDate)</p>
+            <p class="heading-medium" id="processed-date">@messages("cds.sub02.outcome.eori-already-associated.received", dateFormatter.format(processedDate))</p>
         </div>
 
         <h2 class="heading-small" id="vatRegisteredHeading">@messages("cds.subscription.outcomes.eori-already-associated.vat-registered-heading")</h2>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub02_eori_already_exists.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub02_eori_already_exists.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback)
+@this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
 @(name: String, processedDate: String)(implicit messages: Messages, request: Request[_])
 
 
@@ -25,7 +26,7 @@
     <div class="column-two-thirds">
         <div class="govuk-box-highlight">
             <h1 id="page-heading" class="heading-xlarge">@messages("cds.sub02.outcome.eori-already-exists.heading", name)</h1>
-            <p class="heading-medium" id="processed-date">@messages("cds.sub02.outcome.eori-already-exists.received", processedDate)</p>
+            <p class="heading-medium" id="processed-date">@messages("cds.sub02.outcome.eori-already-exists.received", dateFormatter.format(processedDate))</p>
         </div>
 
         <h2 class="heading-small" id="vatRegisteredHeading">@messages("cds.subscription.outcomes.rejected.vat-registered-heading")</h2>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub02_subscription_in_progress.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub02_subscription_in_progress.scala.html
@@ -17,9 +17,10 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback)
+@this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
 @(name: String, processedDate: String)(implicit messages: Messages, request: Request[_])
 
 
@@ -27,7 +28,7 @@
     <div class="column-two-thirds">
         <div class="govuk-box-highlight">
             <h1 id="page-heading" class="heading-xlarge">@messages("cds.sub02.outcome.subscription-in-progress.heading", name)</h1>
-            <p id="processed-date" class="heading-medium">@messages("cds.sub02.outcome.subscription-in-progress.received", processedDate)</p>
+            <p id="processed-date" class="heading-medium">@messages("cds.sub02.outcome.subscription-in-progress.received", dateFormatter.format(processedDate))</p>
         </div>
         <h2 id="what-happens-next" class="heading-medium">@messages("cds.sub02.outcome.subscription-in-progress.what-happens-next")</h2>
         <p id="we-are-processing">

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/subscription_outcome.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/subscription_outcome.scala.html
@@ -17,9 +17,10 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback)
+@this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
 @(eori: String, name: String, processedDate: String)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("cds.subscription.outcomes.success.title")) {
@@ -29,7 +30,7 @@
             @messages("cds.subscription.outcomes.success.heading", name)<br>
             <strong id="eori-number">@eori</strong>
         </h1>
-        <p class="heading-medium" id="issued-date">@messages("cds.subscription.outcomes.success.issued") @processedDate</p>
+        <p class="heading-medium" id="issued-date">@messages("cds.subscription.outcomes.success.issued") @dateFormatter.format(processedDate)</p>
     </div>
 
     <div id='additional-information' class="form-group">

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/subscription_outcome_fail.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/subscription_outcome_fail.scala.html
@@ -18,16 +18,17 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.shortName
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help)
+@this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
 @(processedDate: String, name: String, service: Service)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("cds.subscription.outcomes.rejected.title", shortName), suppressTelephoneNumberDetection = false) {
 <div class="column-two-thirds">
     <div class="govuk-box-highlight">
         <h1 id="page-heading" class="heading-xlarge">@messages("cds.subscription.outcomes.rejected.heading", shortName, name) </h1>
-        <div class="heading-medium" id="active-from">@messages("cds.subscription.outcomes.rejected.received", processedDate)</div>
+        <div class="heading-medium" id="active-from">@messages("cds.subscription.outcomes.rejected.received", dateFormatter.format(processedDate))</div>
     </div>
 
     @helpers.feedbackBackContinue(service, JourneyStatus.Failed)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/subscription_outcome_pending.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/subscription_outcome_pending.scala.html
@@ -18,16 +18,17 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 
 
-@this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help)
+@this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
 @(eori: String, processedDate: String, name: String, service: Service)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("cds.subscription.outcomes.in-processing.title"), suppressTelephoneNumberDetection = false) {
     <div class="column-two-thirds">
         <div class="govuk-box-highlight">
             <h1 id="page-heading" class="heading-xlarge">@messages("cds.subscription.outcomes.in-processing.heading", name)</h1>
-            <div class="heading-medium" id="active-from">@messages("cds.subscription.outcomes.in-processing.received", processedDate)</div>
+            <div class="heading-medium" id="active-from">@messages("cds.subscription.outcomes.in-processing.received", dateFormatter.format(processedDate))</div>
             <div class="heading-medium" id="eori-number">@messages("cds.subscription.outcomes.inprocessing.eori", eori)</div>
         </div>
 

--- a/test/unit/views/DateFormatterSpec.scala
+++ b/test/unit/views/DateFormatterSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.views
+
+import play.api.i18n.{Messages, MessagesApi, MessagesImpl}
+import play.i18n.Lang
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
+import util.ViewSpec
+
+class DateFormatterSpec extends ViewSpec {
+
+  private val dateFormatter = instanceOf[DateFormatter]
+
+  private val messageApi: MessagesApi = instanceOf[MessagesApi]
+
+  "DateFormatter" should {
+
+    "convert string with expected format" in {
+      dateFormatter.format("1 Feb 2020") mustBe "1 February 2020"
+    }
+
+    "convert string with expected format to Welsh" in {
+      implicit val welshMessages: Messages = MessagesImpl(Lang.forCode("cy"), messageApi)
+
+      dateFormatter.format("28 Aug 2020")(welshMessages) mustBe "28 Awst 2020"
+    }
+
+    "return invalid date string unchanged" in {
+      dateFormatter.format("invalid date format") mustBe "invalid date format"
+    }
+
+  }
+}

--- a/test/unit/views/registration/SubscriptionCompleteSpec.scala
+++ b/test/unit/views/registration/SubscriptionCompleteSpec.scala
@@ -42,7 +42,7 @@ class SubscriptionCompleteSpec extends ViewSpec {
       doc.body.getElementsByTag("h1").hasClass("heading-xlarge") mustBe true
     }
     "have the correct processing date and text" in {
-      doc.body.getElementById("issued-date").text mustBe s"issued by HMRC on $issuedDate"
+      doc.body.getElementById("issued-date").text mustBe s"issued by HMRC on 1 January 2019"
     }
   }
 

--- a/test/unit/views/subscription/Sub01OutcomeProcessingSpec.scala
+++ b/test/unit/views/subscription/Sub01OutcomeProcessingSpec.scala
@@ -46,7 +46,7 @@ class Sub01OutcomeProcessingSpec extends ViewSpec {
       docWithName.body.getElementById("processed-date").hasClass("heading-medium") mustBe true
     }
     "have the correct processing date and text" in {
-      docWithName.body.getElementById("processed-date").text mustBe s"Application received by HMRC on $processedDate"
+      docWithName.body.getElementById("processed-date").text mustBe s"Application received by HMRC on 1 January 2019"
     }
     "have the correct 'what happens next' text" in {
       docWithName.body
@@ -68,7 +68,7 @@ class Sub01OutcomeProcessingSpec extends ViewSpec {
       docWithoutName.body.getElementById("processed-date").hasClass("heading-medium") mustBe true
     }
     "have the correct processing date and text" in {
-      docWithoutName.body.getElementById("processed-date").text mustBe s"Application received by HMRC on $processedDate"
+      docWithoutName.body.getElementById("processed-date").text mustBe s"Application received by HMRC on 1 January 2019"
     }
     "have the correct 'what happens next' text" in {
       docWithoutName.body

--- a/test/unit/views/subscription/Sub01OutcomeRejectedSpec.scala
+++ b/test/unit/views/subscription/Sub01OutcomeRejectedSpec.scala
@@ -49,7 +49,7 @@ class Sub01OutcomeRejectedSpec extends ViewSpec {
       docWithName().body.getElementById("processed-date").hasClass("heading-medium") mustBe true
     }
     "have the correct processing date and text" in {
-      docWithName().body.getElementById("processed-date").text mustBe s"Application received by HMRC on $processedDate"
+      docWithName().body.getElementById("processed-date").text mustBe s"Application received by HMRC on 1 January 2019"
     }
 
     "have a feedback 'continue' button" in {
@@ -81,7 +81,7 @@ class Sub01OutcomeRejectedSpec extends ViewSpec {
     "have the correct processing date and text" in {
       docWithoutName().body.getElementById(
         "processed-date"
-      ).text mustBe s"Application received by HMRC on $processedDate"
+      ).text mustBe s"Application received by HMRC on 1 January 2019"
     }
 
     "have a feedback 'continue' button" in {

--- a/test/unit/views/subscription/SubscriptionOutcomeFailSpec.scala
+++ b/test/unit/views/subscription/SubscriptionOutcomeFailSpec.scala
@@ -51,7 +51,7 @@ class SubscriptionOutcomeFailSpec extends ViewSpec {
       doc().body.getElementById("active-from").hasClass("heading-medium") mustBe true
     }
     "have the correct processing date and text" in {
-      doc().body.getElementById("active-from").text mustBe s"Application received by HMRC on $processedDate"
+      doc().body.getElementById("active-from").text mustBe s"Application received by HMRC on 1 January 2019"
     }
 
     "have a feedback 'continue' button" in {

--- a/test/unit/views/subscription/SubscriptionOutcomePendingSpec.scala
+++ b/test/unit/views/subscription/SubscriptionOutcomePendingSpec.scala
@@ -31,7 +31,7 @@ class SubscriptionOutcomePendingSpec extends ViewSpec {
 
   val orgName       = "Test Organisation Name"
   val eoriNumber    = "EORI123"
-  val processedDate = "01 Jan 2019"
+  val processedDate = "01 Feb 2020"
 
   "'Subscription Pending' Page" should {
 
@@ -48,7 +48,7 @@ class SubscriptionOutcomePendingSpec extends ViewSpec {
       doc().body.getElementById("eori-number").hasClass("heading-medium") mustBe true
     }
     "have the correct processing date and text" in {
-      doc().body.getElementById("active-from").text mustBe s"Application received by HMRC on $processedDate"
+      doc().body.getElementById("active-from").text mustBe s"Application received by HMRC on 1 February 2020"
     }
     "have the correct eori number" in {
       doc().body.getElementById("eori-number").text mustBe s"EORI number: $eoriNumber"


### PR DESCRIPTION
- also converts abbreviated months (Jan) to full name (January)

Dates are passed as strings to most (not all) of our "confirmation/error" screens.  As a result they cannot be easily translated using the HMRC play LanguageUtils.

The use of dates is wide-spread throughout the service.  So to minimise the impact of this fix I've created a 'helper' in the view package that will attempt to convert a date string of the form "dd MMM yyyy" to a LocalDate and then translate it (where required).

If this fails (e.g. date is in a different format for some reason) the helper returns the input date string.  So the fix should be fairly safe to deploy.