### PR TITLE
ECC-975 Remove unnecessary cache deletion

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/YouCannotUseServiceController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/YouCannotUseServiceController.scala
@@ -58,18 +58,14 @@ class YouCannotUseServiceController @Inject() (
 
   def unableToUseIdPage(service: Service): Action[AnyContent] = authAction.ggAuthorisedUserWithEnrolmentsAction {
     implicit request => _: LoggedInUserWithEnrolments =>
-      cache.eori.flatMap { eoriOpt =>
-        cache.remove.map { _ =>
-          eoriOpt match {
-            case Some(eori) => Ok(unableToUseIdPage(service, eori))
-            case _ =>
-              Redirect(
-                uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.WhatIsYourEoriController.createForm(
-                  service
-                )
-              )
-          }
-        }
+      cache.eori.map {
+        case Some(eori) => Ok(unableToUseIdPage(service, eori))
+        case _ =>
+          Redirect(
+            uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.WhatIsYourEoriController.createForm(
+              service
+            )
+          )
       }
   }
 


### PR DESCRIPTION
From the ticket https://jira.tools.tax.service.gov.uk/browse/ECC-975

### Logic before:

1. If Enrolment already exists for a logged in User they are redirected to `unable-to-use-id` page (page mentioned in this ticket)
2. On `unable-to-use-id` page load a cache check is done: if Eori number is in the cache -> `unable-to-use-id` page is loaded, if not -> user is redirected to `/matching/use-this-eori` where user can confirm that this is Eori they want to use and continue subscription journey.
3. Very important last step: cache is deleted just after cache check in step 2. What this means - if a user refreshes the `unable-to-use-id` page or clicks Welsh translation they will get always redirected to `matching/use-this-eori` page (as cache was deleted on the first page load/visit).

### Logic after the change: 

This gets rid of cache deletion (step 3) - user with existing enrolment would not be able to come and continue to `/matching/use-this-eori` page and would always get `unable-to-use-id` page presented with logout option.

Notes: cahce here is SessionCache with 40mins TTL.