### PR TITLE
ECC-981 refactor access logic to check enrolment at a later stage

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EnrolmentAlreadyExistsController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EnrolmentAlreadyExistsController.scala
@@ -35,16 +35,14 @@ class EnrolmentAlreadyExistsController @Inject() (
   mcc: MessagesControllerComponents
 ) extends FrontendController(mcc) with I18nSupport {
 
-  // Note: permitted for user with service enrolment
   def enrolmentAlreadyExists(service: Service): Action[AnyContent] =
-    authAction.ggAuthorisedUserWithServiceAction {
+    authAction.ggAuthorisedUserAction {
       implicit request => _: LoggedInUserWithEnrolments =>
         Future.successful(Ok(registrationExistsView(service)))
     }
 
-  // Note: permitted for user with service enrolment
   def enrolmentAlreadyExistsForGroup(service: Service): Action[AnyContent] =
-    authAction.ggAuthorisedUserWithServiceAction {
+    authAction.ggAuthorisedUserAction {
       implicit request => _: LoggedInUserWithEnrolments =>
         Future.successful(Ok(registrationExistsForGroupView(service)))
     }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
@@ -33,7 +33,7 @@ trait AccessController extends AllowlistVerification {
     credentialRole: Option[CredentialRole],
     enrolments: Set[Enrolment],
     email: Option[String]
-  )(action: Future[Result])(implicit request: Request[AnyContent]): Future[Result] = {
+  )(action: => Future[Result])(implicit request: Request[AnyContent]): Future[Result] = {
 
     def hasEnrolment(implicit request: Request[AnyContent]): Boolean =
       Service.serviceFromRequest.exists(service => enrolments.exists(_.key.equalsIgnoreCase(service.enrolmentKey)))

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
@@ -42,9 +42,14 @@ trait AccessController extends AllowlistVerification {
 
     def isPermittedUserType: Boolean =
       affinityGroup match {
-        case Some(Agent)        => false
-        case Some(Organisation) => credentialRole.fold(false)(cr => cr == User)
-        case _                  => true
+        case Some(Agent) => false
+        case _           => true
+      }
+
+    def isPermittedCredentialRole: Boolean =
+      credentialRole match {
+        case Some(User) => true
+        case _          => false
       }
 
     if (!isPermittedEmail(email)) // TODO Check if we would like to keep email allowlisting
@@ -53,6 +58,8 @@ trait AccessController extends AllowlistVerification {
       Future.successful(Redirect(routes.YouCannotUseServiceController.page(service)))
     else if (hasEnrolment)
       Future.successful(Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(service)))
+    else if (!isPermittedCredentialRole)
+      Future.successful(Redirect(routes.YouCannotUseServiceController.page(service)))
     else
       action
   }

--- a/test/unit/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/controllers/ApplicationControllerSpec.scala
@@ -251,7 +251,7 @@ class ApplicationControllerSpec extends ControllerSpec with BeforeAndAfterEach w
         verify(mockSessionCache).saveEori(any())(any())
       }
 
-      "enrolment is not in use but user is Assistant" in {
+      "enrolment is not in use (user does not have any enrolments) and user's Credential Role is set to Assistant" in {
 
         when(groupEnrolmentExtractor.groupIdEnrolmentTo(any(), ArgumentMatchers.eq(atarService))(any()))
           .thenReturn(Future.successful(None))

--- a/test/unit/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/controllers/ApplicationControllerSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import play.api.mvc.Request
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment}
+import uk.gov.hmrc.auth.core.{Assistant, AuthConnector, CredentialRole, Enrolment}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.GroupEnrolmentExtractor
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.{ApplicationController, MissingGroupId}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{EnrolmentResponse, ExistingEori, KeyValue}
@@ -181,6 +181,25 @@ class ApplicationControllerSpec extends ControllerSpec with BeforeAndAfterEach w
       await(result).header.headers("Location") should endWith("enrolment-already-exists")
     }
 
+    "inform authenticated Assistant users with ATAR enrolment that subscription exists" in {
+      val atarEnrolment = Enrolment("HMRC-ATAR-ORG").withIdentifier("EORINumber", "GB134123")
+
+      withAuthorisedUser(
+        defaultUserId,
+        mockAuthConnector,
+        otherEnrolments = Set(atarEnrolment),
+        userCredentialRole = Some(Assistant)
+      )
+
+      val result =
+        controller.startSubscription(atarService).apply(
+          SessionBuilder.buildRequestWithSessionAndPath("/atar/subscribe", defaultUserId)
+        )
+
+      status(result) shouldBe SEE_OTHER
+      await(result).header.headers("Location") should endWith("enrolment-already-exists")
+    }
+
     "inform authenticated users where group Id has an enrolment that subscription exists" in {
 
       when(groupEnrolmentExtractor.hasGroupIdEnrolmentTo(any(), ArgumentMatchers.eq(atarService))(any()))
@@ -230,6 +249,31 @@ class ApplicationControllerSpec extends ControllerSpec with BeforeAndAfterEach w
         status(result) shouldBe SEE_OTHER
         await(result).header.headers("Location") should endWith("unable-to-use-id")
         verify(mockSessionCache).saveEori(any())(any())
+      }
+
+      "enrolment is not in use but user is Assistant" in {
+
+        when(groupEnrolmentExtractor.groupIdEnrolmentTo(any(), ArgumentMatchers.eq(atarService))(any()))
+          .thenReturn(Future.successful(None))
+        when(groupEnrolmentExtractor.groupIdEnrolments(any())(any())).thenReturn(
+          Future.successful(List(groupEnrolment(atarService).get))
+        )
+        when(mockEnrolmentStoreProxyService.isEnrolmentInUse(any(), any())(any())).thenReturn(Future.successful(None))
+        when(mockSessionCache.saveEori(any())(any())).thenReturn(Future.successful(true))
+
+        withAuthorisedUser(
+          defaultUserId,
+          mockAuthConnector,
+          otherEnrolments = Set.empty[Enrolment],
+          userCredentialRole = Some(Assistant)
+        )
+
+        val result =
+          controller.startSubscription(atarService).apply(SessionBuilder.buildRequestWithSession(defaultUserId))
+
+        status(result) shouldBe SEE_OTHER
+        await(result).header.headers("Location") should endWith("you-cannot-use-service")
+
       }
     }
 

--- a/test/unit/filters/UserTypeFilterSpec.scala
+++ b/test/unit/filters/UserTypeFilterSpec.scala
@@ -73,6 +73,26 @@ class UserTypeFilterSpec extends ControllerSpec with BeforeAndAfterEach with Aut
       status(result) shouldBe SEE_OTHER
     }
 
+    "return Redirect (303) when an organisation with an assistant account attempts to access a route with existing enrollment" in {
+      val atarEnrolment = Enrolment("HMRC-ATAR-ORG").withIdentifier("EORINumber", "GB134123")
+
+      AuthBuilder.withAuthorisedUser(
+        "user-1236213",
+        mockAuthConnector,
+        userAffinityGroup = AffinityGroup.Organisation,
+        userCredentialRole = Some(Assistant),
+        otherEnrolments = Set(atarEnrolment)
+      )
+
+      val result = controller
+        .download()
+        .apply(
+          SessionBuilder.buildRequestWithSessionAndPath("/customs-enrolment-services/atar/subscribe/", defaultUserId)
+        )
+
+      await(result).header.headers(LOCATION) should endWith("enrolment-already-exists")
+    }
+
     "return Redirect (303) when an organisation with an assistant account attempts to access a route the URL should contain you cannot use this service" in {
       AuthBuilder.withAuthorisedUser(
         "user-1236213",


### PR DESCRIPTION
Changing the order of the checks during authorisation call - https://jira.tools.tax.service.gov.uk/browse/ECC-981.

Previous order:

1. Check User type (Agent check) & email check (checking Cred Role was included in User Type check)
2. Check enrolment

New order:

1. Check User type (Agent check) & email check
2. Check enrolment
3. Organisation Cred Role Assistant check

(as in https://github.com/hmrc/customs-rosm-frontend/pull/62 and https://github.com/hmrc/eori-common-component-registration-frontend/pull/29)