### PR TITLE
Introduce new save4later key for CDS auto-enrolment journey

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/email/WhatIsYourEmailController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/email/WhatIsYourEmailController.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.eoricommoncomponent.frontend.controllers.email
 
-import javax.inject.{Inject, Singleton}
 import play.api.mvc._
-import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.CdsController
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{GroupId, LoggedInUserWithEnrolments}
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.email.EmailForm.emailForm
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.email.{EmailStatus, EmailViewModel}
@@ -28,6 +27,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.email._
 import uk.gov.hmrc.http.HeaderCarrier
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -70,7 +70,7 @@ class WhatIsYourEmailController @Inject() (
     subscribeJourney: SubscribeJourney
   )(implicit hc: HeaderCarrier): Future[Result] =
     save4LaterService
-      .saveEmail(groupId, EmailStatus(Some(formData.email)))
+      .saveEmailForService(EmailStatus(Some(formData.email)))(service, subscribeJourney, groupId)
       .flatMap(_ => Future.successful(Redirect(routes.CheckYourEmailController.createForm(service, subscribeJourney))))
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/Save4LaterService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/Save4LaterService.scala
@@ -66,12 +66,12 @@ class Save4LaterService @Inject() (save4LaterConnector: Save4LaterConnector) {
     else
       saveEmail(groupId, emailStatus)
 
-  def saveCdsEmail(groupId: GroupId, emailStatus: EmailStatus)(implicit hc: HeaderCarrier): Future[Unit] = {
+  private def saveCdsEmail(groupId: GroupId, emailStatus: EmailStatus)(implicit hc: HeaderCarrier): Future[Unit] = {
     logger.debug(s"saving CDS email address $emailStatus for groupId $groupId")
     save4LaterConnector.put[EmailStatus](groupId.id, cdsEmailKey, emailStatus)
   }
 
-  def fetchCdsEmail(groupId: GroupId)(implicit hc: HeaderCarrier): Future[Option[EmailStatus]] = {
+  private def fetchCdsEmail(groupId: GroupId)(implicit hc: HeaderCarrier): Future[Option[EmailStatus]] = {
     logger.debug(s"fetching CDS EmailStatus groupId $groupId")
     save4LaterConnector
       .get[EmailStatus](groupId.id, cdsEmailKey)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/Save4LaterService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/Save4LaterService.scala
@@ -50,6 +50,10 @@ class Save4LaterService @Inject() (save4LaterConnector: Save4LaterConnector) {
       .put[CdsOrganisationType](groupId.id, orgTypeKey, mayBeOrgType)
   }
 
+  /*
+   * For CDS Short Auto-Enrolment journey we are using a separate save4later cache key in order to allow capturing user's
+   * email for every new subscription.
+   * */
   def fetchEmailForService(service: Service, subscribeJourney: SubscribeJourney, groupId: GroupId)(implicit
     hc: HeaderCarrier
   ): Future[Option[EmailStatus]] =

--- a/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
+++ b/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
@@ -26,7 +26,6 @@ import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.email.CheckYourEmailController
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.GroupId
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.email.EmailStatus
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Service, SubscribeJourney}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
@@ -87,11 +86,11 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
   val unit       = ()
 
   override def beforeEach: Unit = {
-    when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))
-      .thenReturn(Future.successful(Some(emailStatus)))
-
     when(mockEmailVerificationService.createEmailVerificationRequest(any[String], any[String])(any[HeaderCarrier]))
       .thenReturn(Future.successful(Some(true)))
+
+    when(mockSave4LaterService.fetchEmailForService(any(), any(), any())(any()))
+      .thenReturn(Future.successful(Some(emailStatus)))
   }
 
   override def afterEach(): Unit =
@@ -131,12 +130,8 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
         .thenReturn(Future.successful(Some("GB123456789")))
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
         .thenReturn(Future.successful(Some(true)))
-      when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(emailStatus.copy(isVerified = true))))
-      when(
-        mockSave4LaterService
-          .saveEmail(any[GroupId], any[EmailStatus])(any[HeaderCarrier])
-      ).thenReturn(Future.successful(unit))
+      when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
+        .thenReturn(Future.successful(()))
       when(mockSessionCache.saveEmail(any[String])(any[Request[AnyContent]]))
         .thenReturn(Future.successful(true))
 
@@ -153,12 +148,8 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
     }
 
     "redirect to Are You based in UK for Already verified email (Long Journey)" in {
-      when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(emailStatus.copy(isVerified = true))))
-      when(
-        mockSave4LaterService
-          .saveEmail(any[GroupId], any[EmailStatus])(any[HeaderCarrier])
-      ).thenReturn(Future.successful(unit))
+      when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
+        .thenReturn(Future.successful(()))
       when(mockSessionCache.saveEmail(any[String])(any[Request[AnyContent]]))
         .thenReturn(Future.successful(true))
 
@@ -181,13 +172,8 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
       when(mockSessionCache.eori(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some("GB123456789")))
 
-      when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(emailStatus.copy(isVerified = true))))
-
-      when(
-        mockSave4LaterService
-          .saveEmail(any[GroupId], any[EmailStatus])(any[HeaderCarrier])
-      ).thenReturn(Future.successful(unit))
+      when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
+        .thenReturn(Future.successful(()))
 
       when(mockSessionCache.saveEmail(any[String])(any[Request[AnyContent]]))
         .thenReturn(Future.successful(true))
@@ -206,13 +192,9 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
     }
 
     "do not update verified email for Long Journey" in {
-      when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(emailStatus.copy(isVerified = true))))
 
-      when(
-        mockSave4LaterService
-          .saveEmail(any[GroupId], any[EmailStatus])(any[HeaderCarrier])
-      ).thenReturn(Future.successful(unit))
+      when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
+        .thenReturn(Future.successful(()))
 
       when(mockSessionCache.saveEmail(any[String])(any[Request[AnyContent]]))
         .thenReturn(Future.successful(true))
@@ -231,13 +213,8 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
     }
 
     "do not update verified email for non-CDS Short Journey" in {
-      when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(emailStatus.copy(isVerified = true))))
-
-      when(
-        mockSave4LaterService
-          .saveEmail(any[GroupId], any[EmailStatus])(any[HeaderCarrier])
-      ).thenReturn(Future.successful(unit))
+      when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
+        .thenReturn(Future.successful(()))
 
       when(mockSessionCache.saveEmail(any[String])(any[Request[AnyContent]]))
         .thenReturn(Future.successful(true))

--- a/test/unit/controllers/email/WhatIsYourEmailControllerSpec.scala
+++ b/test/unit/controllers/email/WhatIsYourEmailControllerSpec.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.email.WhatIsYourEmailController
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.GroupId
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.email.EmailStatus
-import uk.gov.hmrc.eoricommoncomponent.frontend.models.{AutoEnrolment, SubscribeJourney}
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.{AutoEnrolment, Service, SubscribeJourney}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.email.what_is_your_email
 import uk.gov.hmrc.http.HeaderCarrier
@@ -39,12 +39,10 @@ import scala.concurrent.Future
 
 class WhatIsYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEach with AuthActionMock {
 
-  private val mockAuthConnector = mock[AuthConnector]
-  private val mockAuthAction    = authAction(mockAuthConnector)
-
+  private val mockAuthConnector     = mock[AuthConnector]
   private val mockSave4LaterService = mock[Save4LaterService]
-
-  private val whatIsYourEmailView = instanceOf[what_is_your_email]
+  private val mockAuthAction        = authAction(mockAuthConnector)
+  private val whatIsYourEmailView   = instanceOf[what_is_your_email]
 
   private val controller =
     new WhatIsYourEmailController(mockAuthAction, mcc, whatIsYourEmailView, mockSave4LaterService)
@@ -56,13 +54,11 @@ class WhatIsYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEa
   val unpopulatedEmailFieldsMap = Map("email" -> "")
 
   override def beforeEach: Unit = {
-    when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))
+    when(mockSave4LaterService.fetchEmailForService(any(), any(), any())(any()))
       .thenReturn(Future.successful(Some(emailStatus)))
 
-    when(
-      mockSave4LaterService
-        .saveEmail(any[GroupId], any[EmailStatus])(any[HeaderCarrier])
-    ).thenReturn(Future.successful(()))
+    when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
+      .thenReturn(Future.successful(()))
   }
 
   "What Is Your Email form in create mode" should {
@@ -118,11 +114,13 @@ class WhatIsYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEa
   private def submitFormInCreateMode(
     form: Map[String, String],
     userId: String = defaultUserId,
-    journey: SubscribeJourney
+    journey: SubscribeJourney,
+    service: Service = atarService,
+    controller: WhatIsYourEmailController = controller
   )(test: Future[Result] => Any) {
     withAuthorisedUser(userId, mockAuthConnector)
     val result =
-      controller.submit(atarService, journey)(SessionBuilder.buildRequestWithSessionAndFormValues(userId, form))
+      controller.submit(service, journey)(SessionBuilder.buildRequestWithSessionAndFormValues(userId, form))
     test(result)
   }
 


### PR DESCRIPTION
- add new key to `save4later` service to separate the CDS Email address storage for the short journey
- enforces for every new CDS subscription to ask for Email input during short journey