### PR TITLE
ECC-1233 redirect on DataUnavailableException

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/CdsErrorHandler.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/CdsErrorHandler.scala
@@ -81,7 +81,7 @@ class CdsErrorHandler @Inject() (
         // $COVERAGE-OFF$Loggers
         logger.warn("DataUnavailableException with message - " + dataUnavailableException.message)
         // $COVERAGE-ON
-        Future.successful(Results.InternalServerError(errorTemplateView()))
+        Future.successful(Redirect(ApplicationController.startSubscription(service)))
       case _ =>
         // $COVERAGE-OFF$Loggers
         logger.error("Internal server error: " + exception.getMessage, exception)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/subscription/CompletedEnrolmentController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/subscription/CompletedEnrolmentController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.CdsController
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.{AuthAction, EnrolmentExtractor}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.LoggedInUserWithEnrolments
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{DataUnavailableException, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.eori_enrol_success
 
 import scala.concurrent.ExecutionContext
@@ -40,7 +40,7 @@ class CompletedEnrolmentController @Inject() (
     implicit request => implicit loggedInUser: LoggedInUserWithEnrolments =>
       activatedEnrolmentForService(loggedInUser, service) match {
         case Some(eori) => sessionCache.remove.map(_ => Ok(enrolSuccessView(eori.id, service)))
-        case _          => throw new IllegalStateException("No enrolment found for the user")
+        case _          => throw DataUnavailableException("No enrolment found for the user")
       }
   }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/cache/sessionCache.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/cache/sessionCache.scala
@@ -158,11 +158,7 @@ class SessionCache @Inject() (
 
   def registerWithEoriAndIdResponse(implicit request: Request[_]): Future[RegisterWithEoriAndIdResponse] =
     getData[RegisterWithEoriAndIdResponse](registerWithEoriAndIdResponseKey).map(
-      _.getOrElse(
-        throw new IllegalStateException(
-          s"$registerWithEoriAndIdResponseKey is not cached in data for the sessionId: $sessionId"
-        )
-      )
+      _.getOrElse(throwException(registerWithEoriAndIdResponseKey))
     )
 
   def safeId(implicit request: Request[_]): Future[SafeId] = fetchSafeIdFromRegDetails.flatMap {

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ val compileDependencies = Seq(
   "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.6.0",
   "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.9.0-play-28",
   "uk.gov.hmrc" %% "domain" % "6.1.0-play-28",
-  "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"           % "0.62.0",
+  "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"           % "0.68.0",
   "uk.gov.hmrc" %% "emailaddress" % "3.5.0",
   "uk.gov.hmrc" %% "logback-json-logger" % "5.1.0",
   "uk.gov.hmrc" %% "play-language" % "5.0.0-play-28",

--- a/test/integration/SessionCacheServiceSpec.scala
+++ b/test/integration/SessionCacheServiceSpec.scala
@@ -229,10 +229,10 @@ class SessionCacheSpec extends IntegrationTestsSpec with MockitoSugar with Mongo
       caught.getMessage startsWith s"regDetails is not cached in data for the sessionId: sessionId-123"
     }
 
-    "throw IllegalStateException when registerWithEoriAndIdResponse is not present in cache" in {
+    "throw DataUnavailableException when registerWithEoriAndIdResponse is not present in cache" in {
       when(request.session).thenReturn(Session(Map(("sessionId", "sessionId-123"))))
       await(sessionCache.putSession(DataKey("sub01Outcome"), data = Json.toJson(sub01Outcome)))
-      val caught = intercept[IllegalStateException] {
+      val caught = intercept[DataUnavailableException] {
         await(sessionCache.registerWithEoriAndIdResponse(request))
       }
       caught.getMessage startsWith s"registerWithEoriAndIdResponse is not cached in data for the sessionId: sessionId-123"

--- a/test/unit/controllers/CdsErrorHandlerSpec.scala
+++ b/test/unit/controllers/CdsErrorHandlerSpec.scala
@@ -22,7 +22,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.LOCATION
 import play.api.test.Helpers._
 import uk.gov.hmrc.eoricommoncomponent.frontend.CdsErrorHandler
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionTimeOutException
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{DataUnavailableException, SessionTimeOutException}
 import uk.gov.hmrc.eoricommoncomponent.frontend.util.{Constants, InvalidUrlValueException}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.{client_error_template, error_template, notFound}
 import util.ControllerSpec
@@ -39,6 +39,15 @@ class CdsErrorHandlerSpec extends ControllerSpec with ScalaFutures {
     new CdsErrorHandler(messagesApi, configuration, errorTemplateView, clientErrorTemplateView, notFoundView)
 
   "Cds error handler" should {
+    "redirect to start page after receiving DataUnavailableException exception" in {
+      val mockSubscribeRequest = FakeRequest(method = "GET", "/atar/subscribe")
+
+      whenReady(cdsErrorHandler.onServerError(mockSubscribeRequest, DataUnavailableException("boom"))) { result =>
+        status(result) shouldBe SEE_OTHER
+        result.header.headers(LOCATION) shouldBe "/customs-enrolment-services/atar/subscribe"
+      }
+    }
+
     "redirect to correct page after receive 500 error" in {
       whenReady(cdsErrorHandler.onServerError(mockRequest, new Exception())) { result =>
         val page = CdsPage(contentAsString(result))

--- a/test/unit/controllers/subscription/CompletedEnrolmentControllerSpec.scala
+++ b/test/unit/controllers/subscription/CompletedEnrolmentControllerSpec.scala
@@ -23,7 +23,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.auth.core.{AuthConnector, Enrolment, EnrolmentIdentifier}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.CompletedEnrolmentController
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{DataUnavailableException, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.eori_enrol_success
 import util.ControllerSpec
 import util.builders.AuthActionMock
@@ -76,7 +76,7 @@ class CompletedEnrolmentControllerSpec extends ControllerSpec with AuthActionMoc
 
         withAuthorisedUser(defaultUserId, mockAuthConnector)
 
-        intercept[IllegalStateException] {
+        intercept[DataUnavailableException] {
           await(controller.enrolSuccess(atarService)(getRequest))
         }
       }


### PR DESCRIPTION
Currently, `DataUnavailableException` is thrown in most cases when reading non-existent element from session cache.

For consistency I’ve updated methods in `SessionCache` which read data from session cache to throw this exception instead of `IlegalArgumentException`.

`DataUnavailableException` usage report: [data_unavailable_exception_usage.txt](https://github.com/hmrc/eori-common-component-frontend/files/9280377/data_unavailable_exception_usage.txt)


SessionCache is currently cleared on:
- Sign Out / Log Out
- Display of Subscription result (last page from Long Journey, Sub02Controller)
- Sub01 Subscription Status result (pending / fail)

Proposed solution based on previous discussions:
On `DataUnavailableException` redirect the user to the beginning of the journey. In a scenario where the user has completed the Long Subscription user journey on the last page refresh this would cause journey to be effectively restarted. Depending on how quickly the ETMP systems update (and the enrolment added to the user's GG account) this would mean that the user after refreshing the page would need to go through the full journey again to get the status screen.

ECC Subscribe Journey map: https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=ECC&title=Journey+Flow+maps