### PR TITLE
Move audit events and logging change

### DIFF
--- a/test/unit/connector/UpdateVerifiedEmailConnectorSpec.scala
+++ b/test/unit/connector/UpdateVerifiedEmailConnectorSpec.scala
@@ -93,7 +93,7 @@ class UpdateVerifiedEmailConnectorSpec
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
-  val connector = new UpdateVerifiedEmailConnector(mockAppConfig, mockHttpClient, mockAuditable)
+  val connector = new UpdateVerifiedEmailConnector(mockAppConfig, mockHttpClient)
 
   before {
     reset(mockAuditable, mockAppConfig, mockHttpClient)
@@ -119,7 +119,7 @@ class UpdateVerifiedEmailConnectorSpec
         )
       ).thenReturn(Future.successful(verifiedEmailResponse))
       val result = connector
-        .updateVerifiedEmail(verifiedEmailRequest, Some("old-email-address"))
+        .updateVerifiedEmail(verifiedEmailRequest)
         .futureValue
       result shouldBe Right(verifiedEmailResponse)
     }
@@ -139,7 +139,7 @@ class UpdateVerifiedEmailConnectorSpec
       ).thenReturn(Future.failed(forbiddenException))
 
       val result =
-        connector.updateVerifiedEmail(verifiedEmailRequest, None).futureValue
+        connector.updateVerifiedEmail(verifiedEmailRequest).futureValue
       result shouldBe Left(Forbidden)
     }
 
@@ -158,7 +158,7 @@ class UpdateVerifiedEmailConnectorSpec
       ).thenReturn(Future.failed(forbidden))
 
       val result =
-        connector.updateVerifiedEmail(verifiedEmailRequest, None).futureValue
+        connector.updateVerifiedEmail(verifiedEmailRequest).futureValue
       result shouldBe Left(Forbidden)
     }
 
@@ -177,7 +177,7 @@ class UpdateVerifiedEmailConnectorSpec
       ).thenReturn(Future.failed(badRequestException))
 
       val result =
-        connector.updateVerifiedEmail(verifiedEmailRequest, None).futureValue
+        connector.updateVerifiedEmail(verifiedEmailRequest).futureValue
       result shouldBe Left(BadRequest)
     }
 
@@ -196,7 +196,7 @@ class UpdateVerifiedEmailConnectorSpec
       ).thenReturn(Future.failed(badRequest))
 
       val result =
-        connector.updateVerifiedEmail(verifiedEmailRequest, None).futureValue
+        connector.updateVerifiedEmail(verifiedEmailRequest).futureValue
       result shouldBe Left(BadRequest)
     }
 
@@ -215,7 +215,7 @@ class UpdateVerifiedEmailConnectorSpec
       ).thenReturn(Future.failed(internalServerException))
 
       val result =
-        connector.updateVerifiedEmail(verifiedEmailRequest, None).futureValue
+        connector.updateVerifiedEmail(verifiedEmailRequest).futureValue
       result shouldBe Left(ServiceUnavailable)
     }
 
@@ -234,7 +234,7 @@ class UpdateVerifiedEmailConnectorSpec
       ).thenReturn(Future.failed(internalServerError))
 
       val result =
-        connector.updateVerifiedEmail(verifiedEmailRequest, None).futureValue
+        connector.updateVerifiedEmail(verifiedEmailRequest).futureValue
       result shouldBe Left(ServiceUnavailable)
     }
 
@@ -253,7 +253,7 @@ class UpdateVerifiedEmailConnectorSpec
       ).thenReturn(Future.failed(unhandledException))
 
       val result =
-        await(connector.updateVerifiedEmail(verifiedEmailRequest, None))
+        await(connector.updateVerifiedEmail(verifiedEmailRequest))
       result shouldBe Left(UnhandledException)
     }
   }


### PR DESCRIPTION
Current auditing events in `UpdateVerifiedEmailConnector` can be misleading as `003` Email Error comes back as HTTP 200 response (error encoded in the body) and would be visible in Splunk, therefore:
- moved both of the audit events `changeEmailAddressConfirmed` and `changeEmailAddressVerified` to be executed only when the response contains expected (correct) Json body
- changed log level to track success to Info to help ruling out duplicate call issue