### PR TITLE
ECC-758 upgrading SBT and dependencies

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/has_existing_eori.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/has_existing_eori.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2022 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import views.html.helper._
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/inputDate.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/helpers/inputDate.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2022 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichDateInput
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/check_your_details.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/check_your_details.scala.html
@@ -1,18 +1,18 @@
 @*
-* Copyright 2022 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
 
 @import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{CdsOrganisationType, ExistingEori, NameIdOrganisationMatchModel}
 @import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.subscription.{AddressViewModel, CompanyRegisteredCountry}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/confirm_contact_address.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/confirm_contact_address.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *@
+
 @import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.email.EmailForm.YesNo
 @import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.subscription.ContactAddressViewModel
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/contact_address.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/contact_address.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/date_of_establishment.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/date_of_establishment.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2022 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import java.time.LocalDate
 @import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 @import uk.gov.hmrc.govukfrontend.views.html.components._

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/reg06_eori_already_linked.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/reg06_eori_already_linked.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2022 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 
 import scala.language.postfixOps
 
-mappings in Universal ++= directory(baseDirectory.value / "public")
+Universal / mappings ++= directory(baseDirectory.value / "public")
 // see https://stackoverflow.com/a/37180566
 
 name := "eori-common-component-frontend"
@@ -51,20 +51,20 @@ def filterTestsOnPackageName(rootPackage: String): String => Boolean = {
 lazy val unitTestSettings =
   inConfig(Test)(Defaults.testTasks) ++
     Seq(
-      testOptions in Test := Seq(Tests.Filter(filterTestsOnPackageName("unit"))),
-      testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
-      fork in Test := true,
-      unmanagedSourceDirectories in Test := Seq((baseDirectory in Test).value / "test"),
+      Test / testOptions := Seq(Tests.Filter(filterTestsOnPackageName("unit"))),
+      Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
+      Test / fork := true,
+      Test / unmanagedSourceDirectories := Seq((Test / baseDirectory).value / "test"),
       addTestReportOption(Test, "test-reports")
     )
 
 lazy val integrationTestSettings =
   inConfig(IntegrationTest)(Defaults.testTasks) ++
     Seq(
-      testOptions in IntegrationTest := Seq(Tests.Filters(Seq(filterTestsOnPackageName("integration")))),
-      testOptions in IntegrationTest += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
-      fork in IntegrationTest := false,
-      parallelExecution in IntegrationTest := false,
+      IntegrationTest / testOptions := Seq(Tests.Filters(Seq(filterTestsOnPackageName("integration")))),
+      IntegrationTest / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
+      IntegrationTest / fork := false,
+      IntegrationTest / parallelExecution := false,
       addTestReportOption(IntegrationTest, "int-test-reports")
     )
 
@@ -76,7 +76,10 @@ lazy val playSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val twirlSettings: Seq[Setting[_]] = Seq(
-  TwirlKeys.templateImports ++= Seq("uk.gov.hmrc.eoricommoncomponent.frontend.views.html._", "uk.gov.hmrc.eoricommoncomponent.frontend.domain._")
+  TwirlKeys.templateImports ++= Seq(
+    "uk.gov.hmrc.eoricommoncomponent.frontend.views.html._",
+    "uk.gov.hmrc.eoricommoncomponent.frontend.domain._"
+  )
 )
 
 lazy val scoverageSettings = {
@@ -84,47 +87,48 @@ lazy val scoverageSettings = {
 
   Seq(
     // Semicolon-separated list of regexs matching classes to exclude
-    ScoverageKeys.coverageExcludedPackages := List("<empty>",
+    ScoverageKeys.coverageExcludedPackages := List(
+      "<empty>",
       "Reverse.*",
       "uk\\.gov\\.hmrc\\.customs\\.rosmfrontend\\.models\\.data\\..*",
       "uk\\.gov\\.hmrc\\.customs\\.rosmfrontend\\.view.*",
       "uk\\.gov\\.hmrc\\.customs\\.rosmfrontend\\.models.*",
       "uk\\.gov\\.hmrc\\.customs\\.rosmfrontend\\.config.*",
       "logger.*\\(.*\\)",
-      ".*(AuthService|BuildInfo|Routes|TestOnly).*").mkString(";"),
-    ScoverageKeys.coverageMinimum := 92,       //TODO increase back to 94%
+      ".*(AuthService|BuildInfo|Routes|TestOnly).*"
+    ).mkString(";"),
+    ScoverageKeys.coverageMinimumStmtTotal := 92, //TODO increase back to 94%
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
-    parallelExecution in Test := false
+    Test / parallelExecution := false
   )
 }
 
 scalastyleConfig := baseDirectory.value / "project" / "scalastyle-config.xml"
 
 val compileDependencies = Seq(
-  "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.6.0",
-  "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.9.0-play-28",
-  "uk.gov.hmrc" %% "domain" % "6.1.0-play-28",
-  "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"           % "0.68.0",
-  "uk.gov.hmrc" %% "emailaddress" % "3.5.0",
-  "uk.gov.hmrc" %% "logback-json-logger" % "5.1.0",
-  "uk.gov.hmrc" %% "play-language" % "5.0.0-play-28",
-  "org.webjars.npm" % "accessible-autocomplete" % "2.0.3",
-  "uk.gov.hmrc" %% "play-frontend-hmrc" % "3.2.0-play-28"
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.6.0",
+  "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.9.0-play-28",
+  "uk.gov.hmrc"       %% "domain"                        % "6.1.0-play-28",
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.68.0",
+  "uk.gov.hmrc"       %% "emailaddress"                  % "3.5.0",
+  "uk.gov.hmrc"       %% "logback-json-logger"           % "5.1.0",
+  "uk.gov.hmrc"       %% "play-language"                 % "5.0.0-play-28",
+  "org.webjars.npm"    % "accessible-autocomplete"       % "2.0.3",
+  "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.2.0-play-28"
 )
 
-
 val testDependencies = Seq(
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test,it",
-  "com.typesafe.play" %% "play-test" % PlayVersion.current % "test,it",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % "test,it",
-  "com.github.tomakehurst" % "wiremock-standalone" % "2.23.2" % "test, it"
-    exclude("org.apache.httpcomponents", "httpclient") exclude("org.apache.httpcomponents", "httpcore"),
-  "org.scalacheck" %% "scalacheck" % "1.14.0" % "test,it",
-  "org.jsoup" % "jsoup" % "1.11.3" % "test,it",
-  "us.codecraft" % "xsoup" % "0.3.1" % "test,it",
-  "org.mockito" % "mockito-core" % "3.0.0" % "test,it",
-  "org.pegdown" % "pegdown" % "1.6.0",
+  "org.scalatest"          %% "scalatest"           % "3.0.8"             % "test,it",
+  "com.typesafe.play"      %% "play-test"           % PlayVersion.current % "test,it",
+  "org.scalatestplus.play" %% "scalatestplus-play"  % "5.0.0"             % "test,it",
+  "com.github.tomakehurst"  % "wiremock-standalone" % "2.23.2"            % "test, it"
+    exclude ("org.apache.httpcomponents", "httpclient") exclude ("org.apache.httpcomponents", "httpcore"),
+  "org.scalacheck"    %% "scalacheck"              % "1.14.0" % "test,it",
+  "org.jsoup"          % "jsoup"                   % "1.11.3" % "test,it",
+  "us.codecraft"       % "xsoup"                   % "0.3.1"  % "test,it",
+  "org.mockito"        % "mockito-core"            % "3.0.0"  % "test,it",
+  "org.pegdown"        % "pegdown"                 % "1.6.0",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-27" % "0.56.0" % "test, it"
 )
 
@@ -133,7 +137,9 @@ libraryDependencies ++= compileDependencies ++ testDependencies
 lazy val silencerSettings: Seq[Setting[_]] = {
   val silencerVersion = "1.7.0"
   Seq(
-    libraryDependencies ++= Seq(compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full)),
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full)
+    ),
     // silence all warnings on autogenerated files
     scalacOptions += "-P:silencer:pathFilters=target/.*",
     // Make sure you only exclude warnings for the project directories, i.e. make builds reproducible

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.5.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,13 +2,13 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.7.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.7.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.4")
 


### PR DESCRIPTION
- upgrading service to use SBT `1.5.x`
- upgrading Play Framework as SBT `1.5.x` is supported only from Play `2.8.8`