### PR TITLE
Accessibility fix - headings out of order

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/what_is_your_eori_check_failed.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/migration/what_is_your_eori_check_failed.scala.html
@@ -28,7 +28,7 @@
         <h1 class="govuk-heading-l">@messages("ecc.subscription.eori-number-invalid")</h1>
 
         <p>@messages("ecc.subscription.eori-number-invalid.entered")</p>
-            <h3 class="govuk-heading-s">@eori</h3>
+            <h2 class="govuk-heading-s">@eori</h2>
             <p>@messages("ecc.subscription.eori-number-invalid.does-not-match")
             </p><br>
             <h2 class="govuk-heading-m">@messages("ecc.subscription.eori-number-invalid-reasons-title")</h2>


### PR DESCRIPTION
Fix based on the results of the ECC accessibility audit: 

https://build.tax.service.gov.uk/job/EORI%20Common%20Component/job/eori-common-component-a11y-subscription-tests/Accessibility_20Check_20Report/