### PR TITLE
ECC-1224 add logic to handle 003 Errors

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/connector/httpparsers/HttpErrorResponse.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/connector/httpparsers/HttpErrorResponse.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.connector.httpparsers
 
 import play.api.libs.json.Json
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.email.{UpdateVerifiedEmailRequest, UpdateVerifiedEmailResponse}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.MessagingServiceParam
 
 sealed trait HttpErrorResponse
 case object BadRequest         extends HttpErrorResponse
@@ -27,10 +28,17 @@ case object UnhandledException extends HttpErrorResponse
 
 sealed trait HttpSuccessResponse
 
-case class VerifiedEmailResponse(updateVerifiedEmailResponse: UpdateVerifiedEmailResponse) extends HttpSuccessResponse
+case class VerifiedEmailResponse(updateVerifiedEmailResponse: UpdateVerifiedEmailResponse) extends HttpSuccessResponse {
+  def getStatus: Option[String] = this.updateVerifiedEmailResponse.responseCommon.statusText
+
+  def getParameters: Option[List[MessagingServiceParam]] =
+    this.updateVerifiedEmailResponse.responseCommon.returnParameters
+
+}
 
 object VerifiedEmailResponse {
-  implicit val format = Json.format[VerifiedEmailResponse]
+  implicit val format            = Json.format[VerifiedEmailResponse]
+  val RequestCouldNotBeProcessed = "003 - Request could not be processed"
 }
 
 case class VerifiedEmailRequest(updateVerifiedEmailRequest: UpdateVerifiedEmailRequest)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmailController.scala
@@ -159,10 +159,7 @@ class EmailController @Inject() (
         // $COVERAGE-OFF$Loggers
         logger.warn("Update Verified Email failed with user-retriable error. Redirecting to error page.")
         // $COVERAGE-ON
-        //Future.successful(Ok(emailErrorPage())) // TODO: uncomment when error page is agreed
-        throw new IllegalArgumentException(
-          "Update Verified Email failed"
-        ) // TODO: replace this with error page when it's ready
+        Future.successful(Ok(emailErrorPage()))
       case Left(_) => throw new IllegalArgumentException("Update Verified Email failed with non-retriable error")
     }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmailController.scala
@@ -29,8 +29,8 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.{AutoEnrolment, Service, 
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
-  NonRetriableError,
-  RetriableError,
+  Error,
+  UpdateEmailError,
   UpdateError,
   UpdateVerifiedEmailService
 }
@@ -138,7 +138,7 @@ class EmailController @Inject() (
       case SubscribeJourney(AutoEnrolment) if service.enrolmentKey == Service.cds.enrolmentKey =>
         for {
           maybeEori <- sessionCache.eori
-          verifiedEmailStatus <- maybeEori.fold(Future.successful(Left(NonRetriableError): Either[UpdateError, Unit])) {
+          verifiedEmailStatus <- maybeEori.fold(Future.successful(Left(Error): Either[UpdateError, Unit])) {
             eori => updateVerifiedEmailService.updateVerifiedEmail(None, email, eori)
           }
         } yield verifiedEmailStatus
@@ -155,7 +155,7 @@ class EmailController @Inject() (
           )
           _ <- sessionCache.saveEmail(email)
         } yield Redirect(CheckYourEmailController.emailConfirmed(service, subscribeJourney))
-      case Left(RetriableError) =>
+      case Left(UpdateEmailError) =>
         // $COVERAGE-OFF$Loggers
         logger.warn("Update Verified Email failed with user-retriable error. Redirecting to error page.")
         // $COVERAGE-ON

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmailController.scala
@@ -28,9 +28,15 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.email.EmailStatus
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.{AutoEnrolment, Service, SubscribeJourney}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.UpdateVerifiedEmailService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
+  NonRetriableError,
+  RetriableError,
+  UpdateError,
+  UpdateVerifiedEmailService
+}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.{Save4LaterService, UserGroupIdSubscriptionStatusCheckService}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.{
+  email_error_template,
   enrolment_pending_against_group_id,
   enrolment_pending_for_user
 }
@@ -48,7 +54,8 @@ class EmailController @Inject() (
   updateVerifiedEmailService: UpdateVerifiedEmailService,
   userGroupIdSubscriptionStatusCheckService: UserGroupIdSubscriptionStatusCheckService,
   enrolmentPendingForUser: enrolment_pending_for_user,
-  enrolmentPendingAgainstGroupId: enrolment_pending_against_group_id
+  enrolmentPendingAgainstGroupId: enrolment_pending_against_group_id,
+  emailErrorPage: email_error_template
 )(implicit ec: ExecutionContext)
     extends CdsController(mcc) with EnrolmentExtractor {
 
@@ -99,17 +106,6 @@ class EmailController @Inject() (
         )(otherUserWithinGroupIsInProcess(service))
     }
 
-  private def updateVerifiedEmail(email: String)(implicit request: Request[AnyContent]) =
-    for {
-      maybeEori <- sessionCache.eori
-      result <- maybeEori.fold(Future.successful(Option(false))) {
-        eori => updateVerifiedEmailService.updateVerifiedEmail(None, email, eori)
-      }
-    } yield result match {
-      case Some(isUpdated) if isUpdated => ()
-      case _                            => throw new IllegalArgumentException("UpdateEmail failed")
-    }
-
   private def checkWithEmailService(
     email: String,
     emailStatus: EmailStatus,
@@ -118,34 +114,7 @@ class EmailController @Inject() (
   )(implicit request: Request[AnyContent], userWithEnrolments: LoggedInUserWithEnrolments): Future[Result] =
     emailVerificationService.isEmailVerified(email).flatMap {
       case Some(true) =>
-        for {
-          _ <- subscribeJourney match {
-            case SubscribeJourney(AutoEnrolment) if service.enrolmentKey == Service.cds.enrolmentKey =>
-              updateVerifiedEmail(
-                email
-              ) //here the email will be updated in case it was existing in save4later before and was not verified.
-            case _ =>
-              Future.successful(
-                ()
-              ) //if it's a Long Journey or Short journey for other services than we do not update email.
-          }
-          _ <- {
-            // $COVERAGE-OFF$Loggers
-            logger.warn("updated verified email status true to save4later")
-            // $COVERAGE-ON
-            save4LaterService.saveEmailForService(emailStatus.copy(isVerified = true))(
-              service,
-              subscribeJourney,
-              GroupId(userWithEnrolments.groupId)
-            )
-          }
-          _ <- {
-            // $COVERAGE-OFF$Loggers
-            logger.warn("saved verified email address true to cache")
-            // $COVERAGE-ON
-            sessionCache.saveEmail(email)
-          }
-        } yield Redirect(CheckYourEmailController.emailConfirmed(service, subscribeJourney))
+        onVerifiedEmail(subscribeJourney, service, email, emailStatus, GroupId(userWithEnrolments.groupId))
       case Some(false) =>
         // $COVERAGE-OFF$Loggers
         logger.warn("verified email address false")
@@ -156,6 +125,45 @@ class EmailController @Inject() (
         logger.error("Couldn't verify email address")
         // $COVERAGE-ON
         Future.successful(Redirect(CheckYourEmailController.verifyEmailView(service, subscribeJourney)))
+    }
+
+  private def onVerifiedEmail(
+    subscribeJourney: SubscribeJourney,
+    service: Service,
+    email: String,
+    emailStatus: EmailStatus,
+    groupId: GroupId
+  )(implicit request: Request[AnyContent]) =
+    (subscribeJourney match {
+      case SubscribeJourney(AutoEnrolment) if service.enrolmentKey == Service.cds.enrolmentKey =>
+        for {
+          maybeEori <- sessionCache.eori
+          verifiedEmailStatus <- maybeEori.fold(Future.successful(Left(NonRetriableError): Either[UpdateError, Unit])) {
+            eori => updateVerifiedEmailService.updateVerifiedEmail(None, email, eori)
+          }
+        } yield verifiedEmailStatus
+      case _ =>
+        //if it's a Long Journey or Short journey for other services than cds we do not update email.
+        Future.successful(Right())
+    }).flatMap {
+      case Right(_) =>
+        for {
+          _ <- save4LaterService.saveEmailForService(emailStatus.copy(isVerified = true))(
+            service,
+            subscribeJourney,
+            groupId
+          )
+          _ <- sessionCache.saveEmail(email)
+        } yield Redirect(CheckYourEmailController.emailConfirmed(service, subscribeJourney))
+      case Left(RetriableError) =>
+        // $COVERAGE-OFF$Loggers
+        logger.warn("Update Verified Email failed with user-retriable error. Redirecting to error page.")
+        // $COVERAGE-ON
+        //Future.successful(Ok(emailErrorPage())) // TODO: uncomment when error page is agreed
+        throw new IllegalArgumentException(
+          "Update Verified Email failed"
+        ) // TODO: replace this with error page when it's ready
+      case Left(_) => throw new IllegalArgumentException("Update Verified Email failed with non-retriable error")
     }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/email/CheckYourEmailController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/email/CheckYourEmailController.scala
@@ -30,8 +30,8 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{DataUnavailableException, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
-  NonRetriableError,
-  RetriableError,
+  Error,
+  UpdateEmailError,
   UpdateError,
   UpdateVerifiedEmailService
 }
@@ -205,7 +205,7 @@ class CheckYourEmailController @Inject() (
       case SubscribeJourney(AutoEnrolment) if service.enrolmentKey == Service.cds.enrolmentKey =>
         for {
           maybeEori <- cdsFrontendDataCache.eori
-          verifiedEmailStatus <- maybeEori.fold(Future.successful(Left(NonRetriableError): Either[UpdateError, Unit])) {
+          verifiedEmailStatus <- maybeEori.fold(Future.successful(Left(Error): Either[UpdateError, Unit])) {
             eori => updateVerifiedEmailService.updateVerifiedEmail(None, email, eori)
           }
         } yield verifiedEmailStatus
@@ -222,7 +222,7 @@ class CheckYourEmailController @Inject() (
           )
           _ <- cdsFrontendDataCache.saveEmail(email)
         } yield Redirect(EmailController.form(service, subscribeJourney))
-      case Left(RetriableError) =>
+      case Left(UpdateEmailError) =>
         logger.warn("Update Verified Email failed with user-retriable error. Redirecting to error page.")
         Future.successful(Ok(emailErrorPage()))
       case Left(_) => throw new IllegalArgumentException("Update Verified Email failed with non-retriable error")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/email/CheckYourEmailController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/email/CheckYourEmailController.scala
@@ -224,10 +224,7 @@ class CheckYourEmailController @Inject() (
         } yield Redirect(EmailController.form(service, subscribeJourney))
       case Left(RetriableError) =>
         logger.warn("Update Verified Email failed with user-retriable error. Redirecting to error page.")
-        //Future.successful(Ok(emailErrorPage())) // TODO: uncomment when error page is agreed
-        throw new IllegalArgumentException(
-          "Update Verified Email failed"
-        ) // TODO: replace this with error page when it's ready
+        Future.successful(Ok(emailErrorPage()))
       case Left(_) => throw new IllegalArgumentException("Update Verified Email failed with non-retriable error")
     }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/SubscriptionRecoveryController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/SubscriptionRecoveryController.scala
@@ -232,8 +232,8 @@ class SubscriptionRecoveryController @Inject() (
     updateVerifiedEmailService
       .updateVerifiedEmail(newEmail = subscriptionInformation.email, eori = subscriptionInformation.eori.id)
       .map {
-        case Some(true) => Some(true)
-        case _          => throw new IllegalArgumentException("UpdateEmail failed")
+        case Right(_) => Some(true)
+        case _        => throw new IllegalArgumentException("UpdateEmail failed")
       }
 
   private def updateSubscription(subscriptionInformation: SubscriptionInformation)(implicit request: Request[_]) =

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/UpdateVerifiedEmailService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/subscription/UpdateVerifiedEmailService.scala
@@ -36,8 +36,8 @@ import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 sealed trait UpdateError
-case object RetriableError    extends UpdateError
-case object NonRetriableError extends UpdateError
+case object UpdateEmailError extends UpdateError
+case object Error            extends UpdateError
 
 class UpdateVerifiedEmailService @Inject() (
   reqCommonGenerator: RequestCommonGenerator,
@@ -82,20 +82,20 @@ class UpdateVerifiedEmailService @Inject() (
             s" - updating verified email unsuccessful with business error/status code: ${status}"
         )
         auditRequest(currentEmail, newEmail, eori, "changeEmailAddressCouldNotBeProcessed", res.getStatus)
-        Future.successful(Left(RetriableError))
+        Future.successful(Left(UpdateEmailError))
 
       case Right(res) =>
         logger.warn(
           "[UpdateVerifiedEmailService][updateVerifiedEmail]" +
             s" - updating verified email unsuccessful with business error/status code: ${res.getStatus.getOrElse("Status text empty")}"
         )
-        Future.successful(Left(NonRetriableError))
+        Future.successful(Left(Error))
 
       case Left(res) =>
         logger.warn(
           s"[UpdateVerifiedEmailService][updateVerifiedEmail] - updating verified email unsuccessful with response: $res"
         )
-        Future.successful(Left(NonRetriableError))
+        Future.successful(Left(Error))
     }
   }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email_error_template.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/email_error_template.scala.html
@@ -1,0 +1,31 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import views.html.helper._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+
+
+@this(layout_di: layout)
+@()(implicit messages: Messages, request: Request[_])
+
+@layout_di(messages("cds.error.title"), displayBackLink = false) {
+
+<div>
+    <h1 class="govuk-heading-xl">@messages("cds.email.error.title")</h1>
+    <p class="govuk-body">@messages("cds.email.error.message.part1")</p>
+    <p class="govuk-body">@messages("cds.email.error.message.part2")</p>
+</div>
+}

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1129,6 +1129,12 @@ cds.error.message.part2=Nid ydym wedi cadw’ch atebion. Pan fydd y gwasanaeth a
 cds.error.helpSupport=Help a chymorth
 cds.error.contact.part1=Ffôn: 0300 200 3705
 cds.error.contact.part2=Ar agor 08:00 i 18:00 o ddydd Llun i ddydd Gwener (ar gau ar wyliau banc).
+
+#Email error page
+cds.email.error.title=TODO
+cds.email.error.message.part1=TODO
+cds.email.error.message.part2=TODO
+
 cds.based-in-uk.page.title=Ydych chi neu’ch sefydliad wedi’i leoli yn y DU?
 cds.based-in-uk.heading=Ydych chi neu’ch sefydliad wedi’i leoli yn y DU?
 cds.based-in-uk.page-error.yes-no-answer=Rhowch wybod i ni a ydych chi neu’ch sefydliad wedi’i leoli yn y DU

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1131,9 +1131,9 @@ cds.error.contact.part1=Ffôn: 0300 200 3705
 cds.error.contact.part2=Ar agor 08:00 i 18:00 o ddydd Llun i ddydd Gwener (ar gau ar wyliau banc).
 
 #Email error page
-cds.email.error.title=TODO
-cds.email.error.message.part1=TODO
-cds.email.error.message.part2=TODO
+cds.email.error.title=Mae’n ddrwg gennym, ond ni allwn eich tanysgrifio i’r Gwasanaeth Datganiadau Tollau
+cds.email.error.message.part1=Mae ein system yn dal i brosesu eich manylion. Bydd hyn yn cymryd awr fel arfer, ond gall gymryd yn hirach.
+cds.email.error.message.part2=Rhowch gynnig arall arni ymhen awr.
 
 cds.based-in-uk.page.title=Ydych chi neu’ch sefydliad wedi’i leoli yn y DU?
 cds.based-in-uk.heading=Ydych chi neu’ch sefydliad wedi’i leoli yn y DU?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1297,6 +1297,11 @@ cds.error.helpSupport=Help and support
 cds.error.contact.part1=Telephone: 0300 322 7067
 cds.error.contact.part2=Open 8am to 6pm, Monday to Friday (except public holidays).
 
+#Email error page
+cds.email.error.title=Sorry, there is a problem with updating your email
+cds.email.error.message.part1=Please try again in 1 hour.
+cds.email.error.message.part2=We have saved your email. When you come back, you will have to start again.
+
 #Are you based in the UK?
 cds.based-in-uk.page.title=Are you or your organisation based in the UK?
 cds.based-in-uk.heading=Are you or your organisation based in the UK?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1298,9 +1298,9 @@ cds.error.contact.part1=Telephone: 0300 322 7067
 cds.error.contact.part2=Open 8am to 6pm, Monday to Friday (except public holidays).
 
 #Email error page
-cds.email.error.title=Sorry, there is a problem with updating your email
-cds.email.error.message.part1=Please try again in 1 hour.
-cds.email.error.message.part2=We have saved your email. When you come back, you will have to start again.
+cds.email.error.title=Sorry, we cannot subscribe you to the Customs Declaration Service
+cds.email.error.message.part1=Our system is still processing your details. This usually takes one hour, but can take longer.
+cds.email.error.message.part2=Try again in one hour.
 
 #Are you based in the UK?
 cds.based-in-uk.page.title=Are you or your organisation based in the UK?

--- a/test/unit/controllers/EmailControllerSpec.scala
+++ b/test/unit/controllers/EmailControllerSpec.scala
@@ -33,9 +33,9 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
   Error,
-  UpdateEmailError,
   SubscriptionProcessing,
   SubscriptionStatusService,
+  UpdateEmailError,
   UpdateVerifiedEmailService
 }
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.{Save4LaterService, UserGroupIdSubscriptionStatusCheckService}

--- a/test/unit/controllers/EmailControllerSpec.scala
+++ b/test/unit/controllers/EmailControllerSpec.scala
@@ -32,8 +32,8 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Service, SubscribeJourne
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
-  NonRetriableError,
-  RetriableError,
+  Error,
+  UpdateEmailError,
   SubscriptionProcessing,
   SubscriptionStatusService,
   UpdateVerifiedEmailService
@@ -208,7 +208,7 @@ class EmailControllerSpec
 
     "do not save email when updating email fails" in new TestFixture {
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier])).thenReturn(
-        Future.successful(Left(NonRetriableError))
+        Future.successful(Left(Error))
       )
       the[IllegalArgumentException] thrownBy showFormSubscription(controller)(
         journey = subscribeJourneyShort,
@@ -223,7 +223,7 @@ class EmailControllerSpec
 
     "do not save email when updating verified email with retriable failure and display error page" in new TestFixture {
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Left(RetriableError)))
+        .thenReturn(Future.successful(Left(UpdateEmailError)))
 
       when(mockSessionCache.eori(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some("GB123456789")))

--- a/test/unit/controllers/EmailControllerSpec.scala
+++ b/test/unit/controllers/EmailControllerSpec.scala
@@ -221,23 +221,22 @@ class EmailControllerSpec
       verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
     }
 
-    //TODO uncomment this test when error screen is ready
-//    "do not save email when updating verified email with retriable failure and display error page" in new TestFixture {
-//      when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-//        .thenReturn(Future.successful(Left(RetriableFailure)))
-//
-//      when(mockSessionCache.eori(any[Request[AnyContent]]))
-//        .thenReturn(Future.successful(Some("GB123456789")))
-//
-//      when(mockEmailVerificationService.createEmailVerificationRequest(any[String], any[String])(any[HeaderCarrier]))
-//        .thenReturn(Future.successful(Some(false)))
-//
-//      showFormSubscription(controller)(journey = subscribeJourneyShort, service = cdsService) { result =>
-//        status(result) shouldBe OK
-//      }
-//
-//      verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
-//    }
+    "do not save email when updating verified email with retriable failure and display error page" in new TestFixture {
+      when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
+        .thenReturn(Future.successful(Left(RetriableError)))
+
+      when(mockSessionCache.eori(any[Request[AnyContent]]))
+        .thenReturn(Future.successful(Some("GB123456789")))
+
+      when(mockEmailVerificationService.createEmailVerificationRequest(any[String], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(Some(false)))
+
+      showFormSubscription(controller)(journey = subscribeJourneyShort, service = cdsService) { result =>
+        status(result) shouldBe OK
+      }
+
+      verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
+    }
 
     "redirect when email verified" in new TestFixture {
       when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))

--- a/test/unit/controllers/EmailControllerSpec.scala
+++ b/test/unit/controllers/EmailControllerSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.mvc.Result
+import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmailController
@@ -32,14 +32,18 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Service, SubscribeJourne
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
+  NonRetriableError,
+  RetriableError,
   SubscriptionProcessing,
   SubscriptionStatusService,
   UpdateVerifiedEmailService
 }
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.{Save4LaterService, UserGroupIdSubscriptionStatusCheckService}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.{
+  email_error_template,
   enrolment_pending_against_group_id,
-  enrolment_pending_for_user
+  enrolment_pending_for_user,
+  error_template
 }
 import uk.gov.hmrc.http.HeaderCarrier
 import util.ControllerSpec
@@ -61,6 +65,7 @@ class EmailControllerSpec
   private val mockUpdateVerifiedEmailService     = mock[UpdateVerifiedEmailService]
   private val enrolmentPendingAgainstGroupIdView = instanceOf[enrolment_pending_against_group_id]
   private val enrolmentPendingForUserView        = instanceOf[enrolment_pending_for_user]
+  private val errorEmailView                     = instanceOf[email_error_template]
 
   private val infoXpath = "//*[@id='info']"
 
@@ -80,7 +85,8 @@ class EmailControllerSpec
       mockUpdateVerifiedEmailService,
       userGroupIdSubscriptionStatusCheckService,
       enrolmentPendingForUserView,
-      enrolmentPendingAgainstGroupIdView
+      enrolmentPendingAgainstGroupIdView,
+      errorEmailView
     )
 
   }
@@ -95,7 +101,7 @@ class EmailControllerSpec
     when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
       .thenReturn(Future.successful(()))
     when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier])).thenReturn(
-      Future.successful(Some(true))
+      Future.successful(Right())
     )
     when(mockSessionCache.saveEmail(any())(any()))
       .thenReturn(Future.successful(true))
@@ -202,7 +208,7 @@ class EmailControllerSpec
 
     "do not save email when updating email fails" in new TestFixture {
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier])).thenReturn(
-        Future.successful(Some(false))
+        Future.successful(Left(NonRetriableError))
       )
       the[IllegalArgumentException] thrownBy showFormSubscription(controller)(
         journey = subscribeJourneyShort,
@@ -210,10 +216,28 @@ class EmailControllerSpec
       ) { result =>
         status(result) shouldBe SEE_OTHER
         await(result).header.headers("Location") should endWith("/cds/subscribe/autoenrolment/email-confirmed")
-      } should have message "UpdateEmail failed"
+      } should have message "Update Verified Email failed with non-retriable error"
 
       verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
     }
+
+    //TODO uncomment this test when error screen is ready
+//    "do not save email when updating verified email with retriable failure and display error page" in new TestFixture {
+//      when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
+//        .thenReturn(Future.successful(Left(RetriableFailure)))
+//
+//      when(mockSessionCache.eori(any[Request[AnyContent]]))
+//        .thenReturn(Future.successful(Some("GB123456789")))
+//
+//      when(mockEmailVerificationService.createEmailVerificationRequest(any[String], any[String])(any[HeaderCarrier]))
+//        .thenReturn(Future.successful(Some(false)))
+//
+//      showFormSubscription(controller)(journey = subscribeJourneyShort, service = cdsService) { result =>
+//        status(result) shouldBe OK
+//      }
+//
+//      verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
+//    }
 
     "redirect when email verified" in new TestFixture {
       when(mockSave4LaterService.fetchEmail(any[GroupId])(any[HeaderCarrier]))

--- a/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
+++ b/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
@@ -31,7 +31,11 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Service, SubscribeJourne
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{NonRetriableError, UpdateVerifiedEmailService}
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
+  NonRetriableError,
+  RetriableError,
+  UpdateVerifiedEmailService
+}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.email.{check_your_email, email_confirmed, verify_your_email}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.email_error_template
 import uk.gov.hmrc.http.HeaderCarrier
@@ -219,24 +223,23 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
       verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
     }
 
-    //TODO uncomment this test when error screen is ready
-//    "do not save email when updating verified email with retriable failure and display error page" in {
-//      when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-//        .thenReturn(Future.successful(Left(RetriableFailure)))
-//
-//      when(mockSessionCache.eori(any[Request[AnyContent]]))
-//        .thenReturn(Future.successful(Some("GB123456789")))
-//
-//      when(mockEmailVerificationService.createEmailVerificationRequest(any[String], any[String])(any[HeaderCarrier]))
-//        .thenReturn(Future.successful(Some(false)))
-//
-//      submitForm(ValidRequest + (yesNoInputName -> answerYes), service = cdsService, journey = subscribeJourneyShort) {
-//        result =>
-//          status(result) shouldBe OK
-//      }
-//
-//      verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
-//    }
+    "do not save email when updating verified email with retriable failure and display error page" in {
+      when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
+        .thenReturn(Future.successful(Left(RetriableError)))
+
+      when(mockSessionCache.eori(any[Request[AnyContent]]))
+        .thenReturn(Future.successful(Some("GB123456789")))
+
+      when(mockEmailVerificationService.createEmailVerificationRequest(any[String], any[String])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(Some(false)))
+
+      submitForm(ValidRequest + (yesNoInputName -> answerYes), service = cdsService, journey = subscribeJourneyShort) {
+        result =>
+          status(result) shouldBe OK
+      }
+
+      verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
+    }
 
     "do not update verified email for Long Journey" in {
 

--- a/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
+++ b/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
@@ -31,8 +31,9 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.{Service, SubscribeJourne
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.UpdateVerifiedEmailService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{NonRetriableError, UpdateVerifiedEmailService}
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.email.{check_your_email, email_confirmed, verify_your_email}
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.email_error_template
 import uk.gov.hmrc.http.HeaderCarrier
 import unit.controllers.CdsPage
 import util.ControllerSpec
@@ -64,6 +65,7 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
   private val checkYourEmailView = instanceOf[check_your_email]
   private val emailConfirmedView = instanceOf[email_confirmed]
   private val verifyYourEmail    = instanceOf[verify_your_email]
+  private val errorTemplate      = instanceOf[email_error_template]
 
   private val controller = new CheckYourEmailController(
     mockAuthAction,
@@ -74,7 +76,8 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
     emailConfirmedView,
     verifyYourEmail,
     mockEmailVerificationService,
-    mockUpdateVerifiedEmailService
+    mockUpdateVerifiedEmailService,
+    errorTemplate
   )
 
   val email       = "test@example.com"
@@ -129,7 +132,7 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
       when(mockSessionCache.eori(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some("GB123456789")))
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(true)))
+        .thenReturn(Future.successful(Right()))
       when(mockSave4LaterService.saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier]))
         .thenReturn(Future.successful(()))
       when(mockSessionCache.saveEmail(any[String])(any[Request[AnyContent]]))
@@ -167,7 +170,7 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
 
     "update verified email for CDS Short Journey (Auto-enrolment)" in {
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(true)))
+        .thenReturn(Future.successful(Right()))
 
       when(mockSessionCache.eori(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some("GB123456789")))
@@ -193,7 +196,7 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
 
     "do not save email when updating email fails" in {
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(None))
+        .thenReturn(Future.successful(Left(NonRetriableError)))
 
       when(mockSessionCache.eori(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some("GB123456789")))
@@ -211,10 +214,29 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
           result.header.headers("Location") should endWith(
             "/customs-enrolment-services/cds/subscribe/autoenrolment/check-user"
           )
-      } should have message "UpdateEmail failed"
+      }
 
       verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
     }
+
+    //TODO uncomment this test when error screen is ready
+//    "do not save email when updating verified email with retriable failure and display error page" in {
+//      when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
+//        .thenReturn(Future.successful(Left(RetriableFailure)))
+//
+//      when(mockSessionCache.eori(any[Request[AnyContent]]))
+//        .thenReturn(Future.successful(Some("GB123456789")))
+//
+//      when(mockEmailVerificationService.createEmailVerificationRequest(any[String], any[String])(any[HeaderCarrier]))
+//        .thenReturn(Future.successful(Some(false)))
+//
+//      submitForm(ValidRequest + (yesNoInputName -> answerYes), service = cdsService, journey = subscribeJourneyShort) {
+//        result =>
+//          status(result) shouldBe OK
+//      }
+//
+//      verify(mockSave4LaterService, times(0)).saveEmailForService(any())(any(), any(), any())(any[HeaderCarrier])
+//    }
 
     "do not update verified email for Long Journey" in {
 

--- a/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
+++ b/test/unit/controllers/email/CheckYourEmailControllerSpec.scala
@@ -32,8 +32,8 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.email.EmailVerificationService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
-  NonRetriableError,
-  RetriableError,
+  Error,
+  UpdateEmailError,
   UpdateVerifiedEmailService
 }
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.email.{check_your_email, email_confirmed, verify_your_email}
@@ -200,7 +200,7 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
 
     "do not save email when updating email fails" in {
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Left(NonRetriableError)))
+        .thenReturn(Future.successful(Left(Error)))
 
       when(mockSessionCache.eori(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some("GB123456789")))
@@ -225,7 +225,7 @@ class CheckYourEmailControllerSpec extends ControllerSpec with BeforeAndAfterEac
 
     "do not save email when updating verified email with retriable failure and display error page" in {
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Left(RetriableError)))
+        .thenReturn(Future.successful(Left(UpdateEmailError)))
 
       when(mockSessionCache.eori(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some("GB123456789")))

--- a/test/unit/controllers/registration/SubscriptionRecoveryControllerSpec.scala
+++ b/test/unit/controllers/registration/SubscriptionRecoveryControllerSpec.scala
@@ -33,8 +33,8 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.RandomUUIDGenerator
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
-  HandleSubscriptionService,
   Error,
+  HandleSubscriptionService,
   SubscriptionDetailsService,
   TaxEnrolmentsService,
   UpdateVerifiedEmailService

--- a/test/unit/controllers/registration/SubscriptionRecoveryControllerSpec.scala
+++ b/test/unit/controllers/registration/SubscriptionRecoveryControllerSpec.scala
@@ -34,6 +34,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.RandomUUIDGenerator
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
   HandleSubscriptionService,
+  NonRetriableError,
   SubscriptionDetailsService,
   TaxEnrolmentsService,
   UpdateVerifiedEmailService
@@ -147,14 +148,14 @@ class SubscriptionRecoveryControllerSpec
         .thenReturn(Some(NameDobMatchModel("fname", Some("mName"), "lname", LocalDate.parse("2019-01-01"))))
 
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(None))
+        .thenReturn(Future.successful(Left(NonRetriableError)))
     }
 
     "call Enrolment Complete with successful SUB09 call for Subscription UK journey, default no UpdateEmail" in {
       setupMockCommon()
 
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(true)))
+        .thenReturn(Future.successful(Right()))
       when(mockSubscriptionDetailsHolder.eoriNumber).thenReturn(Some("testEORInumber"))
       when(mockSessionCache.registerWithEoriAndIdResponse(any[Request[AnyContent]]))
         .thenReturn(Future.successful(mockRegisterWithEoriAndIdResponse))
@@ -196,7 +197,7 @@ class SubscriptionRecoveryControllerSpec
     "call Enrolment Complete with successful SUB09 call for Subscription UK journey using CDS formBundle enrichment when service is CDS, UpdateEmail" in {
       setupMockCommon()
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(true)))
+        .thenReturn(Future.successful(Right()))
       when(mockSubscriptionDetailsHolder.eoriNumber).thenReturn(Some("testEORInumber"))
       when(mockSessionCache.registerWithEoriAndIdResponse(any[Request[AnyContent]]))
         .thenReturn(Future.successful(mockRegisterWithEoriAndIdResponse))
@@ -240,7 +241,7 @@ class SubscriptionRecoveryControllerSpec
     "call Enrolment Complete with successful SUB09 call for Subscription ROW journey" in {
       setupMockCommon()
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(true)))
+        .thenReturn(Future.successful(Right()))
       when(mockRequestSessionData.selectedUserLocation(any[Request[AnyContent]])).thenReturn(Some("eu"))
       when(mockSubscriptionDetailsService.cachedCustomsId(any[Request[AnyContent]]))
         .thenReturn(Future.successful(Some(Utr("someUtr"))))
@@ -280,7 +281,7 @@ class SubscriptionRecoveryControllerSpec
     "call Enrolment Complete with successful SUB09 call for Subscription ROW journey without Identifier" in {
       setupMockCommon()
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Some(true)))
+        .thenReturn(Future.successful(Right()))
       when(mockRequestSessionData.selectedUserLocation(any[Request[AnyContent]])).thenReturn(Some("eu"))
       when(mockSubscriptionDetailsService.cachedCustomsId(any[Request[AnyContent]]))
         .thenReturn(Future.successful(None))

--- a/test/unit/controllers/registration/SubscriptionRecoveryControllerSpec.scala
+++ b/test/unit/controllers/registration/SubscriptionRecoveryControllerSpec.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.RandomUUIDGenerator
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
   HandleSubscriptionService,
-  NonRetriableError,
+  Error,
   SubscriptionDetailsService,
   TaxEnrolmentsService,
   UpdateVerifiedEmailService
@@ -148,7 +148,7 @@ class SubscriptionRecoveryControllerSpec
         .thenReturn(Some(NameDobMatchModel("fname", Some("mName"), "lname", LocalDate.parse("2019-01-01"))))
 
       when(mockUpdateVerifiedEmailService.updateVerifiedEmail(any(), any(), any())(any[HeaderCarrier]))
-        .thenReturn(Future.successful(Left(NonRetriableError)))
+        .thenReturn(Future.successful(Left(Error)))
     }
 
     "call Enrolment Complete with successful SUB09 call for Subscription UK journey, default no UpdateEmail" in {

--- a/test/unit/services/subscription/UpdateVerifiedEmailServiceSpec.scala
+++ b/test/unit/services/subscription/UpdateVerifiedEmailServiceSpec.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.services.subscription
+
+import base.UnitSpec
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfter
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.eoricommoncomponent.frontend.audit.Auditable
+import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
+import uk.gov.hmrc.eoricommoncomponent.frontend.connector.httpparsers.{VerifiedEmailRequest, VerifiedEmailResponse}
+import uk.gov.hmrc.eoricommoncomponent.frontend.connector.{
+  UpdateCustomsDataStoreConnector,
+  UpdateVerifiedEmailConnector
+}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.email.DateTimeUtil.dateTime
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.email.UpdateVerifiedEmailResponse
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.CustomsDataStoreRequest
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.{MessagingServiceParam, ResponseCommon}
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.RequestCommonGenerator
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
+  NonRetriableError,
+  RetriableError,
+  UpdateVerifiedEmailService
+}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.time.{LocalDateTime, ZoneOffset}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class UpdateVerifiedEmailServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfter {
+
+  private val mockRequestCommonGenerator            = mock[RequestCommonGenerator]
+  private val mockUpdateVerifiedEmailConnector      = mock[UpdateVerifiedEmailConnector]
+  private val mockUpdateCustomsDataStoreConnector   = mock[UpdateCustomsDataStoreConnector]
+  private val mockAudit                             = mock[Auditable]
+  private val config                                = mock[AppConfig]
+  private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+
+  private val service = new UpdateVerifiedEmailService(
+    mockRequestCommonGenerator,
+    mockUpdateVerifiedEmailConnector,
+    mockUpdateCustomsDataStoreConnector,
+    mockAudit,
+    config
+  )
+
+  before {
+    reset(mockRequestCommonGenerator)
+    reset(mockUpdateVerifiedEmailConnector)
+    reset(mockUpdateCustomsDataStoreConnector)
+    reset(mockAudit)
+    reset(config)
+  }
+
+  private val verifiedEmailResponse = VerifiedEmailResponse(
+    UpdateVerifiedEmailResponse(
+      ResponseCommon(
+        "OK",
+        None,
+        LocalDateTime.ofEpochSecond(dateTime.getMillis / 1000, 0, ZoneOffset.UTC),
+        Some(List(MessagingServiceParam("ETMPFORMBUNDLENUMBER", "077063075008")))
+      )
+    )
+  )
+
+  private val verifiedEmailResponse003 = VerifiedEmailResponse(
+    UpdateVerifiedEmailResponse(
+      ResponseCommon(
+        "OK",
+        Some("003 - Request could not be processed"),
+        LocalDateTime.ofEpochSecond(dateTime.getMillis / 1000, 0, ZoneOffset.UTC),
+        Some(List())
+      )
+    )
+  )
+
+  private val verifiedEmailResponseOtherError = VerifiedEmailResponse(
+    UpdateVerifiedEmailResponse(
+      ResponseCommon(
+        "OK",
+        Some("Something went wrong"),
+        LocalDateTime.ofEpochSecond(dateTime.getMillis / 1000, 0, ZoneOffset.UTC),
+        Some(List())
+      )
+    )
+  )
+
+  private val verifiedEmailResponseError = VerifiedEmailResponse(
+    UpdateVerifiedEmailResponse(
+      ResponseCommon(
+        "KO",
+        Some("Bad Request"),
+        LocalDateTime.ofEpochSecond(dateTime.getMillis / 1000, 0, ZoneOffset.UTC),
+        Some(List())
+      )
+    )
+  )
+
+  "UpdateVerifiedEmailService" should {
+
+    "Update verified Email successfully" in {
+      when(
+        mockUpdateVerifiedEmailConnector
+          .updateVerifiedEmail(any[VerifiedEmailRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(Right(verifiedEmailResponse)))
+
+      when(
+        mockUpdateCustomsDataStoreConnector
+          .updateCustomsDataStore(any[CustomsDataStoreRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(()))
+
+      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Right((): Unit)
+    }
+
+    "fail with Retriable Failure when Email Update returns 003 status" in {
+      when(
+        mockUpdateVerifiedEmailConnector
+          .updateVerifiedEmail(any[VerifiedEmailRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(Right(verifiedEmailResponse003)))
+
+      when(
+        mockUpdateCustomsDataStoreConnector
+          .updateCustomsDataStore(any[CustomsDataStoreRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(()))
+
+      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(RetriableError)
+    }
+
+    "fail with Non Retriable Failure when Email Update fails with a different status reason" in {
+      when(
+        mockUpdateVerifiedEmailConnector
+          .updateVerifiedEmail(any[VerifiedEmailRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(Right(verifiedEmailResponseOtherError)))
+
+      when(
+        mockUpdateCustomsDataStoreConnector
+          .updateCustomsDataStore(any[CustomsDataStoreRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(()))
+
+      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(NonRetriableError)
+    }
+
+    "fail with Non Retriable Failure when Email Update fails" in {
+      when(
+        mockUpdateVerifiedEmailConnector
+          .updateVerifiedEmail(any[VerifiedEmailRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(Right(verifiedEmailResponseError)))
+
+      when(
+        mockUpdateCustomsDataStoreConnector
+          .updateCustomsDataStore(any[CustomsDataStoreRequest])(any[HeaderCarrier])
+      ).thenReturn(Future.successful(()))
+
+      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(NonRetriableError)
+    }
+  }
+}

--- a/test/unit/services/subscription/UpdateVerifiedEmailServiceSpec.scala
+++ b/test/unit/services/subscription/UpdateVerifiedEmailServiceSpec.scala
@@ -34,8 +34,8 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.Cu
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.{MessagingServiceParam, ResponseCommon}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.RequestCommonGenerator
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription.{
-  NonRetriableError,
-  RetriableError,
+  Error,
+  UpdateEmailError,
   UpdateVerifiedEmailService
 }
 import uk.gov.hmrc.http.HeaderCarrier
@@ -140,7 +140,7 @@ class UpdateVerifiedEmailServiceSpec extends UnitSpec with MockitoSugar with Bef
           .updateCustomsDataStore(any[CustomsDataStoreRequest])(any[HeaderCarrier])
       ).thenReturn(Future.successful(()))
 
-      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(RetriableError)
+      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(UpdateEmailError)
     }
 
     "fail with Non Retriable Failure when Email Update fails with a different status reason" in {
@@ -154,7 +154,7 @@ class UpdateVerifiedEmailServiceSpec extends UnitSpec with MockitoSugar with Bef
           .updateCustomsDataStore(any[CustomsDataStoreRequest])(any[HeaderCarrier])
       ).thenReturn(Future.successful(()))
 
-      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(NonRetriableError)
+      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(Error)
     }
 
     "fail with Non Retriable Failure when Email Update fails" in {
@@ -168,7 +168,7 @@ class UpdateVerifiedEmailServiceSpec extends UnitSpec with MockitoSugar with Bef
           .updateCustomsDataStore(any[CustomsDataStoreRequest])(any[HeaderCarrier])
       ).thenReturn(Future.successful(()))
 
-      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(NonRetriableError)
+      await(service.updateVerifiedEmail(None, "newemail@email.email", "GB0123456789")) shouldBe Left(Error)
     }
   }
 }


### PR DESCRIPTION
Add better error handling so that Email Update 003 errors can be handled gracefully for https://jira.tools.tax.service.gov.uk/browse/ECC-1224

Added explicit audit event for 003 failure:
```
{
  "auditSource": "eori-common-component-frontend",
  "auditType": "changeEmailAddressCouldNotBeProcessed",
  "eventId": "ea027401-6c6e-4a3d-8e25-21b84d95b158",
  "tags": {
    "clientIP": "-",
    "path": "http://localhost:6753/update-verified-email",
    "X-Session-ID": "session-25477e5b-c236-4ef4-986e-60f245bbe2e5",
    "Akamai-Reputation": "-",
    "X-Request-ID": "govuk-tax-0c540260-909a-426e-965f-312c26b3ef5c",
    "deviceID": "xxxx",
    "clientPort": "-",
    "transactionName": "UpdateVerifiedEmailRequestSubmitted"
  },
  "detail": {
    "newEmailAddress": "200Fail@email.com",
    "eori": "GB123456789123",
    "status": "003 - Request could not be processed"
  },
  "generatedAt": "2022-10-13T14:28:02.509+0000",
  "metadata": {
    "sendAttemptAt": "2022-10-13T14:28:02.509+0000",
    "instanceID": "2d40e005-7793-428e-8a86-64ac9127b3df",
    "sequence": 98
  }
}
```