### PR TITLE
ECC-1422: update play library for security issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,30 +107,73 @@ lazy val scoverageSettings = {
 scalastyleConfig := baseDirectory.value / "project" / "scalastyle-config.xml"
 
 val compileDependencies = Seq(
+<<<<<<< HEAD
   "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.16.0",
   "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.9.0-play-28",
   "uk.gov.hmrc"       %% "domain"                        % "6.1.0-play-28",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.68.0",
+=======
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "7.11.0",
+  "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.10.0-play-28",
+  "uk.gov.hmrc"       %% "domain"                        % "8.1.0-play-28",
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.71.0",
+>>>>>>> 33267986 (ECC-1422: Make lib deoendencies the same as registration)
   "uk.gov.hmrc"       %% "emailaddress"                  % "3.5.0",
   "uk.gov.hmrc"       %% "logback-json-logger"           % "5.1.0",
-  "uk.gov.hmrc"       %% "play-language"                 % "5.0.0-play-28",
-  "org.webjars.npm"    % "accessible-autocomplete"       % "2.0.3",
-  "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.2.0-play-28"
+  "uk.gov.hmrc"       %% "play-language"                 % "5.1.0-play-28",
+  "org.webjars.npm"    % "accessible-autocomplete"       % "2.0.4",
+  "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.32.0-play-28"
 )
 
 val testDependencies = Seq(
-  "org.scalatest"          %% "scalatest"           % "3.0.8"             % "test,it",
+  "org.scalatest"          %% "scalatest"           % "3.2.14"            % "test,it",
   "com.typesafe.play"      %% "play-test"           % PlayVersion.current % "test,it",
-  "org.scalatestplus.play" %% "scalatestplus-play"  % "5.0.0"             % "test,it",
+  "org.scalatestplus.play" %% "scalatestplus-play"  % "5.1.0"             % "test,it",
+  "com.github.tomakehurst"  % "wiremock-standalone" % "2.27.2"            % "test, it"
+    exclude ("org.apache.httpcomponents", "httpclient") exclude ("org.apache.httpcomponents", "httpcore"),
+  "org.scalacheck"      %% "scalacheck"              % "1.17.0"   % "test,it",
+  "org.scalatestplus"   %% "scalacheck-1-15"         % "3.2.11.0" % "test,it",
+  "org.jsoup"            % "jsoup"                   % "1.15.3"   % "test,it",
+  "us.codecraft"         % "xsoup"                   % "0.3.5"    % "test,it",
+  "org.mockito"          % "mockito-core"            % "4.8.0"    % "test,it",
+  "org.scalatestplus"   %% "mockito-4-6"             % "3.2.13.0" % "test, it",
+  "org.pegdown"          % "pegdown"                 % "1.6.0",
+  "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28" % "0.71.0"   % "test, it",
+  "com.vladsch.flexmark" % "flexmark-all"            % "0.62.0"   % "test,it"
+)
+
+/*
+val compileDependencies = Seq(
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "7.11.0",
+  "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.10.0-play-28",
+  "uk.gov.hmrc"       %% "domain"                        % "6.1.0-play-28",
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.71.0",
+  "uk.gov.hmrc"       %% "emailaddress"                  % "3.5.0",
+  "uk.gov.hmrc"       %% "logback-json-logger"           % "5.1.0",
+  "uk.gov.hmrc"       %% "play-language"                 % "5.1.0-play-28",
+  "org.webjars.npm"    % "accessible-autocomplete"       % "2.0.4",
+  "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.32.0-play-28"
+)
+
+val testDependencies = Seq(
+  "org.scalatest"          %% "scalatest"           % "3.2.12"            % "test,it",
+  "com.typesafe.play"      %% "play-test"           % PlayVersion.current % "test,it",
+  "org.scalatestplus.play" %% "scalatestplus-play"  % "5.1.0"             % "test,it",
   "com.github.tomakehurst"  % "wiremock-standalone" % "2.23.2"            % "test, it"
     exclude ("org.apache.httpcomponents", "httpclient") exclude ("org.apache.httpcomponents", "httpcore"),
-  "org.scalacheck"    %% "scalacheck"              % "1.14.0" % "test,it",
-  "org.jsoup"          % "jsoup"                   % "1.11.3" % "test,it",
-  "us.codecraft"       % "xsoup"                   % "0.3.1"  % "test,it",
-  "org.mockito"        % "mockito-core"            % "3.0.0"  % "test,it",
+  "org.scalacheck" %% "scalacheck" % "1.16.0" % "test,it",
+  "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % "test,it",
+  "org.jsoup"            % "jsoup"                   % "1.15.3"   % "test,it",
+  "us.codecraft"       % "xsoup"                   % "0.3.5"  % "test,it",
+  "org.mockito" % "mockito-core" % "4.7.0" % "test,it",
+
+  "org.scalatestplus" %% "mockito-4-6" % "3.2.13.0" % "test, it",
   "org.pegdown"        % "pegdown"                 % "1.6.0",
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-27" % "0.56.0" % "test, it"
+  "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28" % "0.71.0"   % "test, it",
+  // "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-27" % "0.56.0" % "test, it",
+  "com.vladsch.flexmark" % "flexmark-all"            % "0.62.0"   % "test,it"
 )
+*/
 
 libraryDependencies ++= compileDependencies ++ testDependencies
 

--- a/build.sbt
+++ b/build.sbt
@@ -107,17 +107,10 @@ lazy val scoverageSettings = {
 scalastyleConfig := baseDirectory.value / "project" / "scalastyle-config.xml"
 
 val compileDependencies = Seq(
-<<<<<<< HEAD
   "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.16.0",
-  "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.9.0-play-28",
-  "uk.gov.hmrc"       %% "domain"                        % "6.1.0-play-28",
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.68.0",
-=======
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "7.11.0",
   "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.10.0-play-28",
   "uk.gov.hmrc"       %% "domain"                        % "8.1.0-play-28",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.71.0",
->>>>>>> 33267986 (ECC-1422: Make lib deoendencies the same as registration)
   "uk.gov.hmrc"       %% "emailaddress"                  % "3.5.0",
   "uk.gov.hmrc"       %% "logback-json-logger"           % "5.1.0",
   "uk.gov.hmrc"       %% "play-language"                 % "5.1.0-play-28",
@@ -142,38 +135,7 @@ val testDependencies = Seq(
   "com.vladsch.flexmark" % "flexmark-all"            % "0.62.0"   % "test,it"
 )
 
-/*
-val compileDependencies = Seq(
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "7.11.0",
-  "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.10.0-play-28",
-  "uk.gov.hmrc"       %% "domain"                        % "6.1.0-play-28",
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.71.0",
-  "uk.gov.hmrc"       %% "emailaddress"                  % "3.5.0",
-  "uk.gov.hmrc"       %% "logback-json-logger"           % "5.1.0",
-  "uk.gov.hmrc"       %% "play-language"                 % "5.1.0-play-28",
-  "org.webjars.npm"    % "accessible-autocomplete"       % "2.0.4",
-  "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.32.0-play-28"
-)
 
-val testDependencies = Seq(
-  "org.scalatest"          %% "scalatest"           % "3.2.12"            % "test,it",
-  "com.typesafe.play"      %% "play-test"           % PlayVersion.current % "test,it",
-  "org.scalatestplus.play" %% "scalatestplus-play"  % "5.1.0"             % "test,it",
-  "com.github.tomakehurst"  % "wiremock-standalone" % "2.23.2"            % "test, it"
-    exclude ("org.apache.httpcomponents", "httpclient") exclude ("org.apache.httpcomponents", "httpcore"),
-  "org.scalacheck" %% "scalacheck" % "1.16.0" % "test,it",
-  "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % "test,it",
-  "org.jsoup"            % "jsoup"                   % "1.15.3"   % "test,it",
-  "us.codecraft"       % "xsoup"                   % "0.3.5"  % "test,it",
-  "org.mockito" % "mockito-core" % "4.7.0" % "test,it",
-
-  "org.scalatestplus" %% "mockito-4-6" % "3.2.13.0" % "test, it",
-  "org.pegdown"        % "pegdown"                 % "1.6.0",
-  "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28" % "0.71.0"   % "test, it",
-  // "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-27" % "0.56.0" % "test, it",
-  "com.vladsch.flexmark" % "flexmark-all"            % "0.62.0"   % "test,it"
-)
-*/
 
 libraryDependencies ++= compileDependencies ++ testDependencies
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/test/base/UnitSpec.scala
+++ b/test/base/UnitSpec.scala
@@ -16,7 +16,9 @@
 
 package base
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.Result
 import play.api.test.Helpers._
 import util.TestData
@@ -24,7 +26,7 @@ import util.TestData
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 
-trait UnitSpec extends WordSpec with Matchers with TestData {
+trait UnitSpec extends AnyWordSpec with Matchers with TestData {
 
   // Convenience to avoid having to wrap andThen() parameters in Future.successful
   // From github.com.hmrc/hmrctest to have a possibility to remove deprecated hmrctest library

--- a/test/common/pages/WebPage.scala
+++ b/test/common/pages/WebPage.scala
@@ -17,9 +17,9 @@
 package common.pages
 
 import org.openqa.selenium.By
-import org.scalatest.MustMatchers
+import org.scalatest.matchers.must.Matchers
 
-trait WebPage extends MustMatchers {
+trait WebPage extends Matchers {
 
   val backLinkXPath: String          = "//*[@id='back-link']"
   val pageLevelErrorSummaryListXPath = "//ul[@class='govuk-error-summary__list']"

--- a/test/integration/AllTheCountriesSpec.scala
+++ b/test/integration/AllTheCountriesSpec.scala
@@ -16,11 +16,12 @@
 
 package integration
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.countries.Countries
 
-class AllTheCountriesSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
+class AllTheCountriesSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
 
   "Countries" should {
     "be filtered according to the enum values that MDG accepts " in {

--- a/test/integration/SessionCacheServiceSpec.scala
+++ b/test/integration/SessionCacheServiceSpec.scala
@@ -33,9 +33,8 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{CachedData, Data
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import uk.gov.hmrc.mongo.CurrentTimestampSupport
 import uk.gov.hmrc.mongo.cache.{CacheItem, DataKey}
-import uk.gov.hmrc.mongo.test.MongoSupport
 import util.builders.RegistrationDetailsBuilder._
-
+import uk.gov.hmrc.mongo.test.MongoSupport
 import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/connector/UpdateVerifiedEmailConnectorSpec.scala
+++ b/test/unit/connector/UpdateVerifiedEmailConnectorSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{doNothing, reset, when}
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import play.api.libs.json.Writes
 import play.api.test.Injecting

--- a/test/unit/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/controllers/ApplicationControllerSpec.scala
@@ -105,7 +105,7 @@ class ApplicationControllerSpec extends ControllerSpec with BeforeAndAfterEach w
 
       status(result) shouldBe SEE_OTHER
       await(result).header.headers("Location") should endWith("check-existing-eori")
-      verifyZeroInteractions(mockSessionCache)
+      verifyNoMoreInteractions(mockSessionCache)
     }
 
     "direct authenticated users to start short-cut subscription and pick other enrolment apart from CDS" in {

--- a/test/unit/controllers/migration/NameDobSoleTraderControllerSpec.scala
+++ b/test/unit/controllers/migration/NameDobSoleTraderControllerSpec.scala
@@ -235,7 +235,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your first name"
         page.getElementsText(firstNameFieldLevelErrorXPath) shouldBe "Error: Enter your first name"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -245,7 +245,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your given name"
         page.getElementsText(firstNameFieldLevelErrorXPath) shouldBe "Error: Enter your given name"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -260,7 +260,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
           firstNameFieldLevelErrorXPath
         ) shouldBe "Error: Enter a given name without invalid characters"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -273,7 +273,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
             firstNameFieldLevelErrorXPath
           ) shouldBe "Error: The first name must be 35 characters or less"
           page.getElementsText("title") should startWith("Error: ")
-          verifyZeroInteractions(mockSubscriptionBusinessService)
+          verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -289,7 +289,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
             firstNameFieldLevelErrorXPath
           ) shouldBe "Error: The given name must be 35 characters or less"
           page.getElementsText("title") should startWith("Error: ")
-          verifyZeroInteractions(mockSubscriptionBusinessService)
+          verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -304,7 +304,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
             firstNameFieldLevelErrorXPath
           ) shouldBe "Error: Enter a first name without invalid characters"
           page.getElementsText("title") should startWith("Error: ")
-          verifyZeroInteractions(mockSubscriptionBusinessService)
+          verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -314,7 +314,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your last name"
         page.getElementsText(lastNameFieldLevelErrorXPath) shouldBe "Error: Enter your last name"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -324,7 +324,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your family name"
         page.getElementsText(lastNameFieldLevelErrorXPath) shouldBe "Error: Enter your family name"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -339,7 +339,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
           lastNameFieldLevelErrorXPath
         ) shouldBe "Error: The family name must be 35 characters or less"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -352,7 +352,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
             lastNameFieldLevelErrorXPath
           ) shouldBe "Error: The last name must be 35 characters or less"
           page.getElementsText("title") should startWith("Error: ")
-          verifyZeroInteractions(mockSubscriptionBusinessService)
+          verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -365,7 +365,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
             lastNameFieldLevelErrorXPath
           ) shouldBe "Error: Enter a last name without invalid characters"
           page.getElementsText("title") should startWith("Error: ")
-          verifyZeroInteractions(mockSubscriptionBusinessService)
+          verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -381,7 +381,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
             lastNameFieldLevelErrorXPath
           ) shouldBe "Error: Enter a family name without invalid characters"
           page.getElementsText("title") should startWith("Error: ")
-          verifyZeroInteractions(mockSubscriptionBusinessService)
+          verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -391,7 +391,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your date of birth"
         page.getElementsText(dobFieldLevelErrorXPath) shouldBe "Error: Enter your date of birth"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -401,7 +401,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your date of birth"
         page.getElementsText(dobFieldLevelErrorXPath) shouldBe "Error: Enter your date of birth"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -411,7 +411,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your date of birth"
         page.getElementsText(dobFieldLevelErrorXPath) shouldBe "Error: Enter your date of birth"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -425,7 +425,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
           dobFieldLevelErrorXPath
         ) shouldBe s"Error: Enter a year between 1900 and ${Year.now.getValue}"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -435,7 +435,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Date of birth must be in the past"
         page.getElementsText(dobFieldLevelErrorXPath) shouldBe "Error: Date of birth must be in the past"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -450,7 +450,7 @@ class NameDobSoleTraderControllerSpec extends SubscriptionFlowSpec with BeforeAn
           dobFieldLevelErrorXPath
         ) shouldBe s"Error: Enter a year between 1900 and ${Year.now.getValue}"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 

--- a/test/unit/controllers/migration/NameIDOrgControllerSpec.scala
+++ b/test/unit/controllers/migration/NameIDOrgControllerSpec.scala
@@ -262,7 +262,7 @@ class NameIDOrgControllerSpec extends SubscriptionFlowSpec with BeforeAndAfterEa
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your registered organisation name"
         page.getElementsText(nameFieldLevelErrorXPath) shouldBe "Error: Enter your registered organisation name"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -277,7 +277,7 @@ class NameIDOrgControllerSpec extends SubscriptionFlowSpec with BeforeAndAfterEa
           nameFieldLevelErrorXPath
         ) shouldBe "Error: The organisation name must be 105 characters or less"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -288,7 +288,7 @@ class NameIDOrgControllerSpec extends SubscriptionFlowSpec with BeforeAndAfterEa
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your UTR number"
         page.getElementsText(utrFieldLevelErrorXPath) shouldBe "Error: Enter your UTR number"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -341,7 +341,7 @@ class NameIDOrgControllerSpec extends SubscriptionFlowSpec with BeforeAndAfterEa
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your registered company name"
         page.getElementsText(nameFieldLevelErrorXPath) shouldBe "Error: Enter your registered company name"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -354,7 +354,7 @@ class NameIDOrgControllerSpec extends SubscriptionFlowSpec with BeforeAndAfterEa
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "The company name must be 105 characters or less"
         page.getElementsText(nameFieldLevelErrorXPath) shouldBe "Error: The company name must be 105 characters or less"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
     "validation error when full name is not submitted for Partnership" in {
@@ -368,7 +368,7 @@ class NameIDOrgControllerSpec extends SubscriptionFlowSpec with BeforeAndAfterEa
         page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your registered partnership name"
         page.getElementsText(nameFieldLevelErrorXPath) shouldBe "Error: Enter your registered partnership name"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 
@@ -387,7 +387,7 @@ class NameIDOrgControllerSpec extends SubscriptionFlowSpec with BeforeAndAfterEa
           nameFieldLevelErrorXPath
         ) shouldBe "Error: The partnership name must be 105 characters or less"
         page.getElementsText("title") should startWith("Error: ")
-        verifyZeroInteractions(mockSubscriptionBusinessService)
+        verifyNoMoreInteractions(mockSubscriptionBusinessService)
       }
     }
 

--- a/test/unit/controllers/registration/UserLocationControllerSpec.scala
+++ b/test/unit/controllers/registration/UserLocationControllerSpec.scala
@@ -23,7 +23,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterEach, mock => _}
+import org.scalatest.BeforeAndAfterEach
 import play.api.mvc.{AnyContent, Request, Result, Session}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector

--- a/test/unit/controllers/subscription/AddressLookupErrorControllerSpec.scala
+++ b/test/unit/controllers/subscription/AddressLookupErrorControllerSpec.scala
@@ -18,7 +18,7 @@ package unit.controllers.subscription
 
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
+import org.mockito.Mockito.{reset, verify, verifyNoMoreInteractions, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
@@ -120,7 +120,7 @@ class AddressLookupErrorControllerSpec extends ControllerSpec with AuthActionMoc
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get shouldBe "/customs-enrolment-services/atar/subscribe/address-postcode"
-        verifyZeroInteractions(mockAddressLookupNoResultsPage)
+        verifyNoMoreInteractions(mockAddressLookupNoResultsPage)
       }
 
       "reviewNoResultsPage method is invoked and address lookup params are not in the cache" in {
@@ -131,7 +131,7 @@ class AddressLookupErrorControllerSpec extends ControllerSpec with AuthActionMoc
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get shouldBe "/customs-enrolment-services/atar/subscribe/address-postcode/review"
-        verifyZeroInteractions(mockAddressLookupNoResultsPage)
+        verifyNoMoreInteractions(mockAddressLookupNoResultsPage)
       }
     }
   }

--- a/test/unit/controllers/subscription/AddressLookupPostcodeControllerSpec.scala
+++ b/test/unit/controllers/subscription/AddressLookupPostcodeControllerSpec.scala
@@ -18,7 +18,7 @@ package unit.controllers.subscription
 
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
+import org.mockito.Mockito.{reset, verify, verifyNoMoreInteractions, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.data.Form
 import play.api.test.Helpers._
@@ -159,7 +159,7 @@ class AddressLookupPostcodeControllerSpec extends ControllerSpec with AuthAction
           await(controller.displayPage(atarService)(getRequest))
         }
 
-        verifyZeroInteractions(mockAddressLookupPostcodePage)
+        verifyNoMoreInteractions(mockAddressLookupPostcodePage)
       }
     }
 
@@ -187,7 +187,7 @@ class AddressLookupPostcodeControllerSpec extends ControllerSpec with AuthAction
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get shouldBe "/customs-enrolment-services/atar/subscribe/address-postcode/results"
-        verifyZeroInteractions(mockAddressLookupPostcodePage)
+        verifyNoMoreInteractions(mockAddressLookupPostcodePage)
       }
 
       "form is correct and user is in the review mode" in {
@@ -201,7 +201,7 @@ class AddressLookupPostcodeControllerSpec extends ControllerSpec with AuthAction
         redirectLocation(
           result
         ).get shouldBe "/customs-enrolment-services/atar/subscribe/address-postcode/results/review"
-        verifyZeroInteractions(mockAddressLookupPostcodePage)
+        verifyNoMoreInteractions(mockAddressLookupPostcodePage)
       }
     }
   }

--- a/test/unit/controllers/subscription/AddressLookupResultsControllerSpec.scala
+++ b/test/unit/controllers/subscription/AddressLookupResultsControllerSpec.scala
@@ -18,7 +18,7 @@ package unit.controllers.subscription
 
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, eq => meq}
-import org.mockito.Mockito.{reset, times, verify, verifyZeroInteractions, when}
+import org.mockito.Mockito.{reset, times, verify, verifyNoMoreInteractions, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
@@ -168,7 +168,7 @@ class AddressLookupResultsControllerSpec extends ControllerSpec with AuthActionM
           await(controller.displayPage(atarService)(getRequest))
         }
 
-        verifyZeroInteractions(mockAddressLookupResultsPage)
+        verifyNoMoreInteractions(mockAddressLookupResultsPage)
       }
     }
 
@@ -471,7 +471,7 @@ class AddressLookupResultsControllerSpec extends ControllerSpec with AuthActionM
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get shouldBe "/customs-enrolment-services/atar/subscribe/matching/review-determine"
-        verifyZeroInteractions(mockAddressLookupResultsPage)
+        verifyNoMoreInteractions(mockAddressLookupResultsPage)
       }
 
       "user is not in review mode and provide correct address" in {
@@ -490,7 +490,7 @@ class AddressLookupResultsControllerSpec extends ControllerSpec with AuthActionM
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get shouldBe "/customs-enrolment-services/atar/subscribe/matching/review-determine"
-        verifyZeroInteractions(mockAddressLookupResultsPage)
+        verifyNoMoreInteractions(mockAddressLookupResultsPage)
       }
     }
   }

--- a/test/unit/controllers/subscription/CompanyRegisteredCountryControllerSpec.scala
+++ b/test/unit/controllers/subscription/CompanyRegisteredCountryControllerSpec.scala
@@ -18,7 +18,7 @@ package unit.controllers.subscription
 
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
+import org.mockito.Mockito.{reset, verify, verifyNoMoreInteractions, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -90,7 +90,7 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
 
       status(result) shouldBe OK
       verify(countryOrganisationPage).apply(any(), any(), any(), any(), ArgumentMatchers.eq(false))(any(), any())
-      verifyZeroInteractions(countryIndividualPage)
+      verifyNoMoreInteractions(countryIndividualPage)
     }
 
     "display individual page" in {
@@ -101,7 +101,7 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
 
       status(result) shouldBe OK
       verify(countryIndividualPage).apply(any(), any(), any(), any(), ArgumentMatchers.eq(false))(any(), any())
-      verifyZeroInteractions(countryOrganisationPage)
+      verifyNoMoreInteractions(countryOrganisationPage)
     }
 
     "display review organisation page" in {
@@ -112,7 +112,7 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
 
       status(result) shouldBe OK
       verify(countryOrganisationPage).apply(any(), any(), any(), any(), ArgumentMatchers.eq(true))(any(), any())
-      verifyZeroInteractions(countryIndividualPage)
+      verifyNoMoreInteractions(countryIndividualPage)
     }
 
     "display review individual page" in {
@@ -123,7 +123,7 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
 
       status(result) shouldBe OK
       verify(countryIndividualPage).apply(any(), any(), any(), any(), ArgumentMatchers.eq(true))(any(), any())
-      verifyZeroInteractions(countryOrganisationPage)
+      verifyNoMoreInteractions(countryOrganisationPage)
     }
 
     "return 400 (BAD_REQUEST) for organisation" when {
@@ -137,7 +137,7 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
 
         status(result) shouldBe BAD_REQUEST
         verify(countryOrganisationPage).apply(any(), any(), any(), any(), ArgumentMatchers.eq(false))(any(), any())
-        verifyZeroInteractions(countryIndividualPage)
+        verifyNoMoreInteractions(countryIndividualPage)
       }
     }
 
@@ -152,7 +152,7 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
 
         status(result) shouldBe BAD_REQUEST
         verify(countryIndividualPage).apply(any(), any(), any(), any(), ArgumentMatchers.eq(false))(any(), any())
-        verifyZeroInteractions(countryOrganisationPage)
+        verifyNoMoreInteractions(countryOrganisationPage)
       }
     }
 
@@ -165,8 +165,8 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
         )
 
         status(result) shouldBe SEE_OTHER
-        verifyZeroInteractions(countryOrganisationPage)
-        verifyZeroInteractions(countryIndividualPage)
+        verifyNoMoreInteractions(countryOrganisationPage)
+        verifyNoMoreInteractions(countryIndividualPage)
       }
 
       "user provide correct country and is not in review mode" in {
@@ -176,8 +176,8 @@ class CompanyRegisteredCountryControllerSpec extends ControllerSpec with AuthAct
         )
 
         status(result) shouldBe SEE_OTHER
-        verifyZeroInteractions(countryOrganisationPage)
-        verifyZeroInteractions(countryIndividualPage)
+        verifyNoMoreInteractions(countryOrganisationPage)
+        verifyNoMoreInteractions(countryIndividualPage)
       }
     }
   }

--- a/test/unit/controllers/subscription/ConfirmContactAddressControllerSpec.scala
+++ b/test/unit/controllers/subscription/ConfirmContactAddressControllerSpec.scala
@@ -20,7 +20,7 @@ import common.pages.subscription.ConfirmContactAddressPage
 import common.support.testdata.subscription.BusinessDatesOrganisationTypeTables
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterEach, mock => _}
+import org.scalatest.BeforeAndAfterEach
 import play.api.mvc._
 import play.api.test.Helpers._
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.ConfirmContactAddressController

--- a/test/unit/controllers/subscription/EoriUnableToUseControllerSpec.scala
+++ b/test/unit/controllers/subscription/EoriUnableToUseControllerSpec.scala
@@ -17,7 +17,7 @@
 package unit.controllers.subscription
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
+import org.mockito.Mockito.{reset, verify, verifyNoMoreInteractions, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -150,7 +150,7 @@ class EoriUnableToUseControllerSpec extends ControllerSpec with AuthActionMock w
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get shouldBe "/customs-enrolment-services/atar/subscribe/matching/what-is-your-eori"
-        verifyZeroInteractions(eoriUnableToUsePage)
+        verifyNoMoreInteractions(eoriUnableToUsePage)
       }
     }
 
@@ -169,7 +169,7 @@ class EoriUnableToUseControllerSpec extends ControllerSpec with AuthActionMock w
         redirectLocation(
           result
         ).get shouldBe "/customs-enrolment-services/atar/subscribe/matching/what-is-your-eori/signout"
-        verifyZeroInteractions(eoriUnableToUsePage)
+        verifyNoMoreInteractions(eoriUnableToUsePage)
       }
     }
   }

--- a/test/unit/controllers/subscription/EoriUnableToUseSignoutControllerSpec.scala
+++ b/test/unit/controllers/subscription/EoriUnableToUseSignoutControllerSpec.scala
@@ -17,7 +17,7 @@
 package unit.controllers.subscription
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
+import org.mockito.Mockito.{reset, verify, verifyNoMoreInteractions, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -80,7 +80,7 @@ class EoriUnableToUseSignoutControllerSpec extends ControllerSpec with AuthActio
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get shouldBe "/customs-enrolment-services/atar/subscribe/logout"
-        verifyZeroInteractions(eoriSignoutPage)
+        verifyNoMoreInteractions(eoriSignoutPage)
       }
     }
 
@@ -95,7 +95,7 @@ class EoriUnableToUseSignoutControllerSpec extends ControllerSpec with AuthActio
         redirectLocation(
           result
         ).get shouldBe "/customs-enrolment-services/atar/subscribe/matching/what-is-your-eori/unable-to-use-id"
-        verifyZeroInteractions(eoriSignoutPage)
+        verifyNoMoreInteractions(eoriSignoutPage)
       }
     }
   }

--- a/test/unit/models/JourneySpec.scala
+++ b/test/unit/models/JourneySpec.scala
@@ -16,11 +16,13 @@
 
 package unit.models
 
-import org.scalatest.{EitherValues, MustMatchers, OptionValues, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
 import play.api.mvc.{PathBindable, QueryStringBindable}
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Journey
 
-class JourneySpec extends WordSpec with MustMatchers with EitherValues with OptionValues {
+class JourneySpec extends AnyWordSpec with Matchers with EitherValues with OptionValues {
 
   "Journey" must {
 

--- a/test/unit/models/ServiceSpec.scala
+++ b/test/unit/models/ServiceSpec.scala
@@ -16,10 +16,12 @@
 
 package unit.models
 
-import org.scalatest.{EitherValues, MustMatchers, OptionValues, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 
-class ServiceSpec extends WordSpec with MustMatchers with EitherValues with OptionValues {
+class ServiceSpec extends AnyWordSpec with Matchers with EitherValues with OptionValues {
 
   "Service" must {
 

--- a/test/unit/services/countries/CountriesSpec.scala
+++ b/test/unit/services/countries/CountriesSpec.scala
@@ -16,11 +16,13 @@
 
 package unit.services.countries
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.countries.{Countries, Country}
 
-class CountriesSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
+class CountriesSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
 
   "Countries" should {
 

--- a/test/unit/services/organisation/OrgTypeLookupSpec.scala
+++ b/test/unit/services/organisation/OrgTypeLookupSpec.scala
@@ -19,7 +19,7 @@ package unit.services.organisation
 import base.UnitSpec
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterEach, mock => _}
+import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{CdsOrganisationType, CorporateBody, Partnership}

--- a/test/unit/services/subscription/CdsSubscriberSpec.scala
+++ b/test/unit/services/subscription/CdsSubscriberSpec.scala
@@ -388,7 +388,7 @@ class CdsSubscriberSpec extends UnitSpec with MockitoSugar with ScalaFutures wit
         await(cdsSubscriber.subscribeWithCachedDetails(atarService))
       }
       caught shouldBe emulatedFailure
-      verifyZeroInteractions(mockSubscriptionService)
+      verifyNoMoreInteractions(mockSubscriptionService)
       verify(mockCdsFrontendDataCache, never).remove(any[Request[AnyContent]])
     }
   }

--- a/test/unit/util/RequireSpec.scala
+++ b/test/unit/util/RequireSpec.scala
@@ -16,10 +16,11 @@
 
 package unit.util
 
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.eoricommoncomponent.frontend.util.{InvalidUrlValueException, Require}
 
-class RequireSpec extends WordSpec with MustMatchers {
+class RequireSpec extends AnyWordSpec with Matchers {
 
   "Require requireThatUrlValue" should {
 

--- a/test/util/builders/AuthActionMock.scala
+++ b/test/util/builders/AuthActionMock.scala
@@ -17,17 +17,17 @@
 package util.builders
 
 import base.Injector
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{AnyContentAsEmpty, DefaultActionBuilder}
-import play.api.{Configuration, Environment}
 import play.api.test.Helpers.stubBodyParser
+import play.api.{Configuration, Environment}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
 
 import scala.concurrent.ExecutionContext.global
 
-trait AuthActionMock extends WordSpec with MockitoSugar with Injector {
+trait AuthActionMock extends AnyWordSpec with MockitoSugar with Injector {
 
   val configuration = instanceOf[Configuration]
   val environment   = Environment.simple()


### PR DESCRIPTION
I tried upgrading to bootstrap play 7.11.0 which resulted in test failures. So upgraded to latest versions of the test libraries, which required code changes. The tests still failed. Rolled back to bootstrap play 5.8.0 which is the earliest version withy the security fix and the tests passed. Integrated a bootstrap play upgrade to 5.16.0 introduced in main by @povilas.