### PR TITLE
ECC-1917: Prevent DataUnavailableException welsh toggle - Pending

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/RegisterWithEoriAndIdController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/RegisterWithEoriAndIdController.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.mvc._
@@ -28,7 +28,6 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.{CdsController, Miss
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.RegisterWithEoriAndIdResponse._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.SubmissionCompleteData
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.registration.{MatchingService, Reg06Service}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/RegisterWithEoriAndIdController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/registration/RegisterWithEoriAndIdController.scala
@@ -22,21 +22,25 @@ import play.api.Logger
 import play.api.mvc._
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.{AuthAction, GroupEnrolmentExtractor}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.registration.routes._
-import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.EnrolmentAlreadyExistsController
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.{
+  ApplicationController,
+  EnrolmentAlreadyExistsController
+}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.subscription.routes.Sub02Controller
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.{CdsController, MissingGroupId}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.RegisterWithEoriAndIdResponse._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.SubmissionCompleteData
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.registration.{MatchingService, Reg06Service}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.subscription._
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.service
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.error_template
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.subscription._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.language.LanguageUtils
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.DataUnavailableException
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -159,29 +163,36 @@ class RegisterWithEoriAndIdController @Inject() (
       } yield Ok(sub01OutcomeRejectedView(Some(name), processedDate, service))
   }
 
-  def pending(service: Service): Action[AnyContent] =
-    authAction.ggAuthorisedUserWithEnrolmentsAction { implicit request => _: LoggedInUserWithEnrolments =>
+  def pending(service: Service): Action[AnyContent] = authAction.ggAuthorisedUserWithEnrolmentsAction {
+    implicit request => _: LoggedInUserWithEnrolments =>
       for {
         submissionCompleteData <- cache.submissionCompleteDetails
         _                      <- cache.remove
         _                      <- cache.saveSubmissionCompleteDetails(submissionCompleteData)
-      } yield Ok(
-        subscriptionOutcomePendingView(
-          submissionCompleteData.subscriptionDetails.getOrElse(
-            throw DataUnavailableException("No subscriptionDetails found within submissionCompleteData in cache")
-          ).eoriNumber.getOrElse(throw DataUnavailableException("No EORI found in cache")),
-          languageUtils.Dates.formatDate(
-            submissionCompleteData.processingDate.getOrElse(
-              throw DataUnavailableException("No processingDate found within submissionCompleteData in cache")
-            ).toLocalDate
-          ),
-          submissionCompleteData.subscriptionDetails.getOrElse(
-            throw DataUnavailableException("No subscriptionDetails found within submissionCompleteData in cache")
-          ).name,
-          service
-        )
-      ).withSession(newUserSession)
+      } yield displaySubscriptionOutcomePendingView(submissionCompleteData, service)
+  }
+
+  private def displaySubscriptionOutcomePendingView(submissionCompleteData: SubmissionCompleteData, service: Service)(
+    implicit request: Request[_]
+  ) = {
+    val result = for {
+      details        <- submissionCompleteData.subscriptionDetails
+      processingDate <- submissionCompleteData.processingDate
+      eoriNumber     <- details.eoriNumber
+    } yield Ok(
+      subscriptionOutcomePendingView(
+        eoriNumber,
+        languageUtils.Dates.formatDate(processingDate.toLocalDate),
+        details.name,
+        service
+      )
+    ).withSession(newUserSession)
+
+    result.getOrElse {
+      logger.warn("Subscription Complete Data not found for this session")
+      Redirect(ApplicationController.startSubscription(service))
     }
+  }
 
   def fail(service: Service, date: String): Action[AnyContent] =
     authAction.ggAuthorisedUserWithEnrolmentsAction { implicit request => _: LoggedInUserWithEnrolments =>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubmissionCompleteData.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubmissionCompleteData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription
+
+import play.api.libs.json.{Format, Json}
+import java.time.LocalDateTime
+
+case class SubmissionCompleteData(
+  subscriptionDetails: Option[SubscriptionDetails] = None,
+  processingDate: Option[LocalDateTime] = None
+)
+
+object SubmissionCompleteData {
+  implicit val format: Format[SubmissionCompleteData] = Json.format[SubmissionCompleteData]
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/cache/sessionCache.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/cache/sessionCache.scala
@@ -123,12 +123,7 @@ class SessionCache @Inject() (
   )(implicit request: Request[_]): Future[Boolean] = for {
     subCompleteDetails <- submissionCompleteDetails
     _                  <- putData(registerWithEoriAndIdResponseKey, Json.toJson(rd)) map (_ => true)
-    _ <- putData(
-      submissionCompleteKey,
-      Json.toJson(
-        SubmissionCompleteData(subCompleteDetails.subscriptionDetails, Some(rd.responseCommon.processingDate))
-      )
-    )
+    _                  <- saveSubmissionCompleteDetails(subCompleteDetails.copy(processingDate = Some(rd.responseCommon.processingDate)))
   } yield true
 
   def saveSub02Outcome(subscribeOutcome: Sub02Outcome)(implicit request: Request[_]): Future[Boolean] =
@@ -140,10 +135,7 @@ class SessionCache @Inject() (
   def saveSubscriptionDetails(rdh: SubscriptionDetails)(implicit request: Request[_]): Future[Boolean] = for {
     subCompleteDetails <- submissionCompleteDetails
     _                  <- putData(subDetailsKey, Json.toJson(rdh)) map (_ => true)
-    _ <- putData(
-      submissionCompleteKey,
-      Json.toJson(SubmissionCompleteData(Some(rdh), subCompleteDetails.processingDate))
-    )
+    _                  <- saveSubmissionCompleteDetails(subCompleteDetails.copy(subscriptionDetails = Some(rdh)))
   } yield true
 
   def saveEmail(email: String)(implicit request: Request[_]): Future[Boolean] =

--- a/test/integration/SessionCacheServiceSpec.scala
+++ b/test/integration/SessionCacheServiceSpec.scala
@@ -163,7 +163,14 @@ class SessionCacheSpec extends IntegrationTestsSpec with MockitoSugar with Mongo
       val cache = await(sessionCache.cacheRepo.findById(request)).getOrElse(
         throw new IllegalStateException("Cache returned None")
       )
-      val expectedJson = toJson(CachedData(registerWithEoriAndIdResponse = Some(rd)))
+
+      val expectedJson = toJson(
+        CachedData(
+          registerWithEoriAndIdResponse = Some(rd),
+          submissionCompleteDetails = Some(SubmissionCompleteData(None, Some(rd.responseCommon.processingDate)))
+        )
+      )
+
       cache.data mustBe expectedJson
 
       await(sessionCache.registerWithEoriAndIdResponse(request)) mustBe rd

--- a/test/integration/SessionCacheServiceSpec.scala
+++ b/test/integration/SessionCacheServiceSpec.scala
@@ -25,7 +25,7 @@ import play.api.mvc.{Request, Session}
 import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.ResponseCommon
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.SubscriptionDetails
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{SubmissionCompleteData, SubscriptionDetails}
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.subscription.AddressLookupParams
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
@@ -35,6 +35,7 @@ import uk.gov.hmrc.mongo.CurrentTimestampSupport
 import uk.gov.hmrc.mongo.cache.DataKey
 import util.builders.RegistrationDetailsBuilder._
 import uk.gov.hmrc.mongo.test.MongoSupport
+
 import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -162,7 +163,6 @@ class SessionCacheSpec extends IntegrationTestsSpec with MockitoSugar with Mongo
       val cache = await(sessionCache.cacheRepo.findById(request)).getOrElse(
         throw new IllegalStateException("Cache returned None")
       )
-
       val expectedJson = toJson(CachedData(registerWithEoriAndIdResponse = Some(rd)))
       cache.data mustBe expectedJson
 
@@ -390,7 +390,12 @@ class SessionCacheSpec extends IntegrationTestsSpec with MockitoSugar with Mongo
         throw new IllegalStateException("Cache returned None")
       )
 
-      val expectedJson = toJson(CachedData(subDetails = Some(subscriptionDetails)))
+      val expectedJson = toJson(
+        CachedData(
+          subDetails = Some(subscriptionDetails),
+          submissionCompleteDetails = Some(SubmissionCompleteData(Some(subscriptionDetails), None))
+        )
+      )
 
       cache.data mustBe expectedJson
     }

--- a/test/integration/SessionCacheServiceSpec.scala
+++ b/test/integration/SessionCacheServiceSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.services.Save4LaterService
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{CachedData, DataUnavailableException, SessionCache}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import uk.gov.hmrc.mongo.CurrentTimestampSupport
-import uk.gov.hmrc.mongo.cache.DataKey
+import uk.gov.hmrc.mongo.cache.{CacheItem, DataKey}
 import util.builders.RegistrationDetailsBuilder._
 import uk.gov.hmrc.mongo.test.MongoSupport
 

--- a/test/unit/controllers/registration/RegisterWithEoriAndIdControllerSpec.scala
+++ b/test/unit/controllers/registration/RegisterWithEoriAndIdControllerSpec.scala
@@ -1153,7 +1153,7 @@ class RegisterWithEoriAndIdControllerSpec
       }
     }
 
-    "throws exception when Eori number is not found for pending function" in {
+    "redirect to start page when cache required for pending function is not available" in {
 
       val subscriptionDetails = SubscriptionDetails(eoriNumber = None, nameDetails = Some(NameMatchModel("John Doe")))
       val submissionCompleteData = SubmissionCompleteData(
@@ -1168,44 +1168,10 @@ class RegisterWithEoriAndIdControllerSpec
       when(mockCache.remove(any[Request[_]]))
         .thenReturn(Future.successful(true))
 
-      intercept[DataUnavailableException] {
-        invokePending()(result => status(result))
-      }.getMessage shouldBe "No EORI found in cache"
-    }
-
-    "throws exception when subscriptionDetails is not found within submissionCompleteData for pending function" in {
-
-      val submissionCompleteData =
-        SubmissionCompleteData(None, Some(stubRegisterWithEoriAndIdResponse().responseCommon.processingDate))
-
-      when(mockCache.submissionCompleteDetails(any[Request[_]]))
-        .thenReturn(Future.successful(submissionCompleteData))
-      when(mockCache.saveSubmissionCompleteDetails(any())(any[Request[_]]))
-        .thenReturn(Future.successful(true))
-      when(mockCache.remove(any[Request[_]]))
-        .thenReturn(Future.successful(true))
-
-      intercept[DataUnavailableException] {
-        invokePending()(result => status(result))
-      }.getMessage shouldBe "No subscriptionDetails found within submissionCompleteData in cache"
-    }
-
-    "throws exception when processingDate is not found within submissionCompleteData for pending function" in {
-
-      val subscriptionDetails =
-        SubscriptionDetails(eoriNumber = Some("123456789"), nameDetails = Some(NameMatchModel("John Doe")))
-      val submissionCompleteData = SubmissionCompleteData(Some(subscriptionDetails), None)
-
-      when(mockCache.submissionCompleteDetails(any[Request[_]]))
-        .thenReturn(Future.successful(submissionCompleteData))
-      when(mockCache.saveSubmissionCompleteDetails(any())(any[Request[_]]))
-        .thenReturn(Future.successful(true))
-      when(mockCache.remove(any[Request[_]]))
-        .thenReturn(Future.successful(true))
-
-      intercept[DataUnavailableException] {
-        invokePending()(result => status(result))
-      }.getMessage shouldBe "No processingDate found within submissionCompleteData in cache"
+      invokePending() { result =>
+        status(result) shouldBe SEE_OTHER
+        result.header.headers("Location") shouldBe "/customs-enrolment-services/atar/subscribe"
+      }
     }
 
     "Call the eoriAlreadyLinked function" in {

--- a/test/unit/controllers/registration/RegisterWithEoriAndIdControllerSpec.scala
+++ b/test/unit/controllers/registration/RegisterWithEoriAndIdControllerSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.RegisterWithEoriAndIdResp
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.{Address, ResponseCommon}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.SubscriptionDetails
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{SubmissionCompleteData, SubscriptionDetails}
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{
   DataUnavailableException,
@@ -1132,17 +1132,19 @@ class RegisterWithEoriAndIdControllerSpec
     }
 
     "Call the pending function" in {
-      when(mockCache.subscriptionDetails(any[Request[_]]))
-        .thenReturn(Future.successful(mockSubscriptionDetails))
-      when(mockSubscriptionDetails.eoriNumber)
-        .thenReturn(Some("someEoriNumber"))
-      when(mockSubscriptionDetails.name).thenReturn("name")
+      val subscriptionDetails =
+        SubscriptionDetails(eoriNumber = Some("123456789"), nameDetails = Some(NameMatchModel("John Doe")))
+      val submissionCompleteData = SubmissionCompleteData(
+        Some(subscriptionDetails),
+        Some(stubRegisterWithEoriAndIdResponse().responseCommon.processingDate)
+      )
+
+      when(mockCache.submissionCompleteDetails(any[Request[_]]))
+        .thenReturn(Future.successful(submissionCompleteData))
+      when(mockCache.saveSubmissionCompleteDetails(any())(any[Request[_]]))
+        .thenReturn(Future.successful(true))
       when(mockCache.remove(any[Request[_]]))
         .thenReturn(Future.successful(true))
-      when(mockCache.saveSubscriptionDetails(any())(any[Request[_]])).thenReturn(Future.successful(true))
-      when(mockCache.registerWithEoriAndIdResponse(any[Request[_]]))
-        .thenReturn(Future.successful(stubRegisterWithEoriAndIdResponse()))
-      when(mockSub01Outcome.processedDate).thenReturn(LocalDateTime.now().toLocalDate.toString)
 
       invokePending() { result =>
         status(result) shouldBe OK
@@ -1152,20 +1154,58 @@ class RegisterWithEoriAndIdControllerSpec
     }
 
     "throws exception when Eori number is not found for pending function" in {
-      when(mockCache.subscriptionDetails(any[Request[_]]))
-        .thenReturn(Future.successful(mockSubscriptionDetails))
-      when(mockSubscriptionDetails.eoriNumber).thenReturn(None)
-      when(mockSubscriptionDetails.name).thenReturn("name")
+
+      val subscriptionDetails = SubscriptionDetails(eoriNumber = None, nameDetails = Some(NameMatchModel("John Doe")))
+      val submissionCompleteData = SubmissionCompleteData(
+        Some(subscriptionDetails),
+        Some(stubRegisterWithEoriAndIdResponse().responseCommon.processingDate)
+      )
+
+      when(mockCache.submissionCompleteDetails(any[Request[_]]))
+        .thenReturn(Future.successful(submissionCompleteData))
+      when(mockCache.saveSubmissionCompleteDetails(any())(any[Request[_]]))
+        .thenReturn(Future.successful(true))
       when(mockCache.remove(any[Request[_]]))
         .thenReturn(Future.successful(true))
-      when(mockCache.saveSubscriptionDetails(any())(any[Request[_]])).thenReturn(Future.successful(true))
-      when(mockCache.registerWithEoriAndIdResponse(any[Request[_]]))
-        .thenReturn(Future.successful(stubRegisterWithEoriAndIdResponse()))
-      when(mockSub01Outcome.processedDate).thenReturn(LocalDateTime.now().toLocalDate.toString)
 
       intercept[DataUnavailableException] {
         invokePending()(result => status(result))
       }.getMessage shouldBe "No EORI found in cache"
+    }
+
+    "throws exception when subscriptionDetails is not found within submissionCompleteData for pending function" in {
+
+      val submissionCompleteData =
+        SubmissionCompleteData(None, Some(stubRegisterWithEoriAndIdResponse().responseCommon.processingDate))
+
+      when(mockCache.submissionCompleteDetails(any[Request[_]]))
+        .thenReturn(Future.successful(submissionCompleteData))
+      when(mockCache.saveSubmissionCompleteDetails(any())(any[Request[_]]))
+        .thenReturn(Future.successful(true))
+      when(mockCache.remove(any[Request[_]]))
+        .thenReturn(Future.successful(true))
+
+      intercept[DataUnavailableException] {
+        invokePending()(result => status(result))
+      }.getMessage shouldBe "No subscriptionDetails found within submissionCompleteData in cache"
+    }
+
+    "throws exception when processingDate is not found within submissionCompleteData for pending function" in {
+
+      val subscriptionDetails =
+        SubscriptionDetails(eoriNumber = Some("123456789"), nameDetails = Some(NameMatchModel("John Doe")))
+      val submissionCompleteData = SubmissionCompleteData(Some(subscriptionDetails), None)
+
+      when(mockCache.submissionCompleteDetails(any[Request[_]]))
+        .thenReturn(Future.successful(submissionCompleteData))
+      when(mockCache.saveSubmissionCompleteDetails(any())(any[Request[_]]))
+        .thenReturn(Future.successful(true))
+      when(mockCache.remove(any[Request[_]]))
+        .thenReturn(Future.successful(true))
+
+      intercept[DataUnavailableException] {
+        invokePending()(result => status(result))
+      }.getMessage shouldBe "No processingDate found within submissionCompleteData in cache"
     }
 
     "Call the eoriAlreadyLinked function" in {


### PR DESCRIPTION
Prevent a `DataUnavailableException` being thrown on the pending screen when either refreshing or using the language switcher. We store subscriptionDetails and processingDate as an additional cache field so we can wipe other cache items to prevent data being available if user goes back to previous page in the journey