### PR TITLE
ECC-1976 use default CSP directives provided by play-bootstrap

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -30,27 +30,6 @@ play.http.errorHandler = "uk.gov.hmrc.eoricommoncomponent.frontend.CdsErrorHandl
 
 play.filters.enabled += play.filters.csp.CSPFilter
 
-#Google Analytics configuration based on https://developers.google.com/tag-platform/tag-manager/web/csp#google_analytics_4_google_analytics
-play.filters.csp {
-  nonce {
-    enabled = true
-    pattern = "%CSP_NONCE_PATTERN%"
-    header = true
-  }
-  directives {
-    base-uri = "'self'"
-    block-all-mixed-content = ""
-    child-src = "'self' https://*.googletagmanager.com"
-    connect-src = "'self' https://stats.g.doubleclick.net https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://*.google.com https://*.google.co.uk"
-    default-src = "'none'"
-    font-src = "'self' https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com"
-    frame-ancestors = "'self'"
-    img-src =  "'self' https://ssl.gstatic.com https://www.gstatic.com https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.g.doubleclick.net https://*.google.com https://*.google.co.uk"
-    script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://*.googletagmanager.com https://tagmanager.google.com https://*.google-analytics.com"
-    style-src = ${play.filters.csp.nonce.pattern} "'self' https://tagmanager.google.com https://fonts.googleapis.com"
-  }
-}
-
 # Router
 # ~~~~~
 # Define the Router object to use for this application.


### PR DESCRIPTION
HMRC `bootstrap-play` from version 7.15.0 provides platform default CSP directives list, therefore we don't need to provide a custom one.

More on this: https://confluence.tools.tax.service.gov.uk/display/TEC/2023/03/31/Bootstrap-play+and+Content+Security+Policies