### PR TITLE
DDCYLS-8288: removing rogue bracket from confirmation screen.

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub01_outcome_processing.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription/sub01_outcome_processing.scala.html
@@ -29,7 +29,7 @@
         @govukPanel(Panel(
             title = HtmlContent(headingForProcessing(orgName)),
             content = HtmlContent(p(messages("cds.subscription.outcomes.in-processing.received", dateFormatter.format(processedDate)), Some("processed-date"), "govuk-!-font-size-36")))
-        ))
+        )
         <div id="what-happens-next">
             @h2(messages("cds.subscription.outcomes.steps.next"))
             @p(messages("cds.sub01.outcome.processing.we-are-processing", shortName), Some("processing-para"))


### PR DESCRIPTION
on the confirmation screen from a application in progress (sub 01 response) there is a rogue bracket.